### PR TITLE
fix+test: extract split logic, fix server component onClick, add tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,8 @@
         "eslint-config-next": "^15.1.0",
         "postcss": "^8",
         "tailwindcss": "^3.4.1",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^3.0.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -808,6 +809,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.19.12",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.12.tgz",
@@ -825,6 +843,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.19.12",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.12.tgz",
@@ -840,6 +875,23 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -1980,6 +2032,356 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -2013,6 +2415,24 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2624,6 +3044,121 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2885,6 +3420,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -3073,6 +3618,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
@@ -3163,6 +3718,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3178,6 +3750,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -3391,6 +3973,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -3758,6 +4350,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -4291,6 +4890,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4299,6 +4908,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -5491,6 +6110,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lucide-react": {
       "version": "0.468.0",
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.468.0.tgz",
@@ -5498,6 +6124,16 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/math-intrinsics": {
@@ -6022,6 +6658,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -6465,6 +7118,51 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -6766,6 +7464,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -6800,6 +7505,20 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
     },
@@ -6952,6 +7671,26 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
@@ -7148,6 +7887,20 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -7194,6 +7947,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -7461,6 +8244,654 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/vite": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -7573,6 +9004,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "db:push": "drizzle-kit push",
     "db:generate": "drizzle-kit generate",
     "db:studio": "drizzle-kit studio",
-    "vercel-build": "npm run db:push && npm run build"
+    "vercel-build": "npm run db:push && npm run build",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "next": "^15.1.0",
@@ -32,6 +34,7 @@
     "tailwindcss": "^3.4.1",
     "postcss": "^8",
     "autoprefixer": "^10.0.1",
-    "drizzle-kit": "^0.29.0"
+    "drizzle-kit": "^0.29.0",
+    "vitest": "^3.0.0"
   }
 }

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -12,6 +12,7 @@ import {
   members,
   settlements,
 } from "@/db/schema";
+import { computeSplits, type SplitInputs, type SplitType } from "@/lib/splits";
 import { generateId } from "@/lib/utils";
 
 // ─── Groups ──────────────────────────────────────────────────────────────────
@@ -51,68 +52,11 @@ export async function addMember(groupId: string, formData: FormData) {
 
 // ─── Expenses ────────────────────────────────────────────────────────────────
 
-type SplitEntry = { memberId: string; amount: number };
-
-function computeSplits(
-  splitType: string,
-  amount: number,
-  participantIds: string[],
-  formData: FormData
-): SplitEntry[] {
-  const count = participantIds.length;
-
-  if (splitType === "equal") {
-    const base = Math.round((amount / count) * 100) / 100;
-    let remaining = amount;
-    return participantIds.map((id, i) => {
-      const a = i === count - 1 ? Math.round(remaining * 100) / 100 : base;
-      remaining -= base;
-      return { memberId: id, amount: a };
-    });
-  }
-
-  if (splitType === "shares") {
-    const shareNums = participantIds.map(
-      (id) => parseFloat(formData.get(`share_${id}`) as string) || 0
-    );
-    const totalShares = shareNums.reduce((s, n) => s + n, 0);
-    if (totalShares === 0) return [];
-    let remaining = amount;
-    return participantIds.map((id, i) => {
-      const a =
-        i === count - 1
-          ? Math.round(remaining * 100) / 100
-          : Math.round((amount * shareNums[i]) / totalShares * 100) / 100;
-      remaining -= i === count - 1 ? 0 : a;
-      return { memberId: id, amount: a };
-    });
-  }
-
-  if (splitType === "percentage") {
-    let remaining = amount;
-    return participantIds.map((id, i) => {
-      const pct = parseFloat(formData.get(`pct_${id}`) as string) || 0;
-      const a =
-        i === count - 1
-          ? Math.round(remaining * 100) / 100
-          : Math.round((amount * pct) / 100 * 100) / 100;
-      remaining -= i === count - 1 ? 0 : a;
-      return { memberId: id, amount: a };
-    });
-  }
-
-  // exact
-  return participantIds.map((id) => ({
-    memberId: id,
-    amount: parseFloat(formData.get(`exact_${id}`) as string) || 0,
-  }));
-}
-
 export async function createExpense(groupId: string, formData: FormData) {
   const description = (formData.get("description") as string).trim();
   const amount = parseFloat(formData.get("amount") as string);
   const paidById = formData.get("paidById") as string;
-  const splitType = formData.get("splitType") as string;
+  const splitType = formData.get("splitType") as SplitType;
   const date = formData.get("date") as string;
   const participantIds = formData.getAll("participants") as string[];
 
@@ -126,7 +70,21 @@ export async function createExpense(groupId: string, formData: FormData) {
   )
     return;
 
-  const splits = computeSplits(splitType, amount, participantIds, formData);
+  // Extract per-participant values from FormData into a plain object so the
+  // pure computeSplits function doesn't depend on browser APIs.
+  const inputs: SplitInputs = {
+    shares: Object.fromEntries(
+      participantIds.map((id) => [id, parseFloat(formData.get(`share_${id}`) as string) || 0])
+    ),
+    percentages: Object.fromEntries(
+      participantIds.map((id) => [id, parseFloat(formData.get(`pct_${id}`) as string) || 0])
+    ),
+    exact: Object.fromEntries(
+      participantIds.map((id) => [id, parseFloat(formData.get(`exact_${id}`) as string) || 0])
+    ),
+  };
+
+  const splits = computeSplits(splitType, Math.round(amount * 100) / 100, participantIds, inputs);
   if (splits.length === 0) return;
 
   const expenseId = generateId();
@@ -136,7 +94,7 @@ export async function createExpense(groupId: string, formData: FormData) {
     description,
     amount: Math.round(amount * 100) / 100,
     paidById,
-    splitType: splitType as "equal" | "shares" | "percentage" | "exact",
+    splitType,
     date,
   });
 

--- a/src/app/groups/[id]/delete-group-button.tsx
+++ b/src/app/groups/[id]/delete-group-button.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { deleteGroup } from "@/app/actions";
+
+export function DeleteGroupButton({ groupId }: { groupId: string }) {
+  const action = deleteGroup.bind(null, groupId);
+  return (
+    <form action={action}>
+      <button
+        type="submit"
+        className="text-xs text-slate-400 hover:text-red-500 transition-colors"
+        onClick={(e) => {
+          if (!confirm("Delete this group and all its expenses? This cannot be undone.")) {
+            e.preventDefault();
+          }
+        }}
+      >
+        Delete group
+      </button>
+    </form>
+  );
+}

--- a/src/app/groups/[id]/page.tsx
+++ b/src/app/groups/[id]/page.tsx
@@ -9,7 +9,8 @@ import { db } from "@/db";
 import { expenses, expenseSplits, groups, members, settlements } from "@/db/schema";
 import { calculateBalances, simplifyDebts } from "@/lib/balances";
 import { formatCurrency, formatDate } from "@/lib/format";
-import { addMember, deleteExpense, deleteGroup } from "@/app/actions";
+import { addMember, deleteExpense } from "@/app/actions";
+import { DeleteGroupButton } from "./delete-group-button";
 
 export default async function GroupPage({
   params,
@@ -213,19 +214,7 @@ export default async function GroupPage({
 
       {/* Danger zone */}
       <section className="pt-2">
-        <form action={deleteGroup.bind(null, id)}>
-          <button
-            type="submit"
-            className="text-xs text-slate-400 hover:text-red-500 transition-colors"
-            onClick={(e) => {
-              if (!confirm("Delete this group and all its expenses? This cannot be undone.")) {
-                e.preventDefault();
-              }
-            }}
-          >
-            Delete group
-          </button>
-        </form>
+        <DeleteGroupButton groupId={id} />
       </section>
     </div>
   );

--- a/src/lib/__tests__/balances.test.ts
+++ b/src/lib/__tests__/balances.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from "vitest";
+import {
+  calculateBalances,
+  simplifyDebts,
+  type Balance,
+  type Expense,
+  type Member,
+  type Settlement,
+} from "../balances";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const m = (id: string): Member => ({ id, name: id });
+
+const exp = (paidById: string, amount: number, splits: [string, number][]): Expense => ({
+  amount,
+  paidById,
+  splits: splits.map(([memberId, a]) => ({ memberId, amount: a })),
+});
+
+const settle = (paidById: string, paidToId: string, amount: number): Settlement => ({
+  paidById,
+  paidToId,
+  amount,
+});
+
+const netOf = (balances: Balance[], id: string) =>
+  balances.find((b) => b.memberId === id)?.net ?? 0;
+
+// ─── calculateBalances ────────────────────────────────────────────────────────
+// Core accounting model:
+//   paying for an expense  → +amount to payer's net
+//   being in a split       → -split_amount from that member's net
+//   recording a settlement → +amount to payer's net, -amount from recipient's net
+//
+// Conservation law: the sum of all net balances is always zero.
+
+describe("calculateBalances", () => {
+  it("credits payer and debits split participants", () => {
+    // Alice pays $10, split equally. Alice's net: +10 (credit) - 5 (her split) = +5.
+    // Bob's net: 0 (credit) - 5 (his split) = -5.
+    const balances = calculateBalances(
+      [m("alice"), m("bob")],
+      [exp("alice", 10, [["alice", 5], ["bob", 5]])],
+      []
+    );
+    expect(netOf(balances, "alice")).toBe(5);
+    expect(netOf(balances, "bob")).toBe(-5);
+  });
+
+  it("payer who is not a split participant is credited the full amount", () => {
+    // Alice pays $30 for bob and carol only. Alice is owed $30 in full.
+    const balances = calculateBalances(
+      [m("alice"), m("bob"), m("carol")],
+      [exp("alice", 30, [["bob", 15], ["carol", 15]])],
+      []
+    );
+    expect(netOf(balances, "alice")).toBe(30);
+    expect(netOf(balances, "bob")).toBe(-15);
+    expect(netOf(balances, "carol")).toBe(-15);
+  });
+
+  it("accumulates balances across multiple expenses", () => {
+    // Expense 1: Alice pays $10 split equally → alice +5, bob -5
+    // Expense 2: Bob pays $6 split equally   → alice -3, bob +3
+    // Net: alice +2, bob -2
+    const balances = calculateBalances(
+      [m("alice"), m("bob")],
+      [
+        exp("alice", 10, [["alice", 5], ["bob", 5]]),
+        exp("bob", 6, [["alice", 3], ["bob", 3]]),
+      ],
+      []
+    );
+    expect(netOf(balances, "alice")).toBe(2);
+    expect(netOf(balances, "bob")).toBe(-2);
+  });
+
+  it("settlements credit the payer and debit the recipient", () => {
+    // After alice pays bob $5 to settle: alice -5, bob +5 from the settlement.
+    // Combined with alice owing bob $5 from an expense, everything nets to 0.
+    const balances = calculateBalances(
+      [m("alice"), m("bob")],
+      [exp("bob", 10, [["alice", 5], ["bob", 5]])],
+      [settle("alice", "bob", 5)]
+    );
+    expect(netOf(balances, "alice")).toBe(0);
+    expect(netOf(balances, "bob")).toBe(0);
+  });
+
+  it("partial settlement reduces but does not eliminate the debt", () => {
+    const balances = calculateBalances(
+      [m("alice"), m("bob")],
+      [exp("bob", 10, [["alice", 5], ["bob", 5]])],
+      [settle("alice", "bob", 3)] // only paid back $3 of $5 owed
+    );
+    expect(netOf(balances, "alice")).toBe(-2);
+    expect(netOf(balances, "bob")).toBe(2);
+  });
+
+  it("all net balances sum to zero (conservation of money)", () => {
+    // Money doesn't appear or disappear — every credit has a matching debit.
+    const balances = calculateBalances(
+      [m("alice"), m("bob"), m("carol"), m("dave")],
+      [
+        exp("alice", 120, [["alice", 30], ["bob", 30], ["carol", 30], ["dave", 30]]),
+        exp("bob", 45, [["alice", 15], ["bob", 15], ["carol", 15]]),
+        exp("carol", 10, [["carol", 5], ["dave", 5]]),
+      ],
+      [settle("dave", "alice", 10), settle("carol", "bob", 8)]
+    );
+    const sum = balances.reduce((s, b) => s + b.net, 0);
+    expect(Math.round(sum * 100) / 100).toBe(0);
+  });
+
+  it("members with no activity have a net of zero", () => {
+    // dave is a member but is not part of any expense or settlement.
+    const balances = calculateBalances(
+      [m("alice"), m("bob"), m("dave")],
+      [exp("alice", 10, [["alice", 5], ["bob", 5]])],
+      []
+    );
+    expect(netOf(balances, "dave")).toBe(0);
+  });
+});
+
+// ─── simplifyDebts ────────────────────────────────────────────────────────────
+// Reduces balances to the minimum number of payments to settle all debts.
+// Uses a greedy algorithm: match the largest debtor to the largest creditor.
+//
+// Key property: the sum of all simplified payments equals the sum of all
+// positive (creditor) balances — i.e. no money is lost or invented.
+
+describe("simplifyDebts", () => {
+  it("returns empty array when everyone is settled up", () => {
+    const balances: Balance[] = [
+      { memberId: "alice", memberName: "alice", net: 0 },
+      { memberId: "bob", memberName: "bob", net: 0 },
+    ];
+    expect(simplifyDebts(balances)).toEqual([]);
+  });
+
+  it("produces a single payment for a simple two-person debt", () => {
+    const balances: Balance[] = [
+      { memberId: "alice", memberName: "alice", net: 10 },  // alice is owed $10
+      { memberId: "bob", memberName: "bob", net: -10 },     // bob owes $10
+    ];
+    const debts = simplifyDebts(balances);
+    expect(debts).toHaveLength(1);
+    expect(debts[0]).toMatchObject({ fromId: "bob", toId: "alice", amount: 10 });
+  });
+
+  it("collapses A→B, B→C chain into a single direct A→C payment", () => {
+    // If alice owes bob $5 and bob owes carol $5, simplification produces
+    // alice → carol $5 directly, eliminating bob as intermediary.
+    const balances: Balance[] = [
+      { memberId: "alice", memberName: "alice", net: -5 },
+      { memberId: "bob", memberName: "bob", net: 0 },
+      { memberId: "carol", memberName: "carol", net: 5 },
+    ];
+    const debts = simplifyDebts(balances);
+    expect(debts).toHaveLength(1);
+    expect(debts[0]).toMatchObject({ fromId: "alice", toId: "carol", amount: 5 });
+  });
+
+  it("produces two payments for two independent debts to the same creditor", () => {
+    // alice and bob both owe carol
+    const balances: Balance[] = [
+      { memberId: "alice", memberName: "alice", net: -3 },
+      { memberId: "bob", memberName: "bob", net: -7 },
+      { memberId: "carol", memberName: "carol", net: 10 },
+    ];
+    const debts = simplifyDebts(balances);
+    expect(debts).toHaveLength(2);
+    const totalPaid = debts.reduce((s, d) => s + d.amount, 0);
+    expect(totalPaid).toBe(10);
+    expect(debts.every((d) => d.toId === "carol")).toBe(true);
+  });
+
+  it("handles multiple creditors and debtors", () => {
+    // alice owes $10 total; bob owes $5 total.
+    // carol is owed $8; dave is owed $7.
+    // Expected: 2–3 payments to clear all debts.
+    const balances: Balance[] = [
+      { memberId: "alice", memberName: "alice", net: -10 },
+      { memberId: "bob", memberName: "bob", net: -5 },
+      { memberId: "carol", memberName: "carol", net: 8 },
+      { memberId: "dave", memberName: "dave", net: 7 },
+    ];
+    const debts = simplifyDebts(balances);
+    const totalPaid = Math.round(debts.reduce((s, d) => s + d.amount, 0) * 100) / 100;
+    expect(totalPaid).toBe(15); // = sum of all positive balances
+    // Every creditor must be fully repaid
+    expect(debts.filter((d) => d.toId === "carol").reduce((s, d) => s + d.amount, 0)).toBe(8);
+    expect(debts.filter((d) => d.toId === "dave").reduce((s, d) => s + d.amount, 0)).toBe(7);
+  });
+
+  it("total payments equal the total positive balance (money is conserved)", () => {
+    const balances: Balance[] = [
+      { memberId: "alice", memberName: "alice", net: 37.5 },
+      { memberId: "bob", memberName: "bob", net: -12.5 },
+      { memberId: "carol", memberName: "carol", net: -15 },
+      { memberId: "dave", memberName: "dave", net: -10 },
+    ];
+    const debts = simplifyDebts(balances);
+    const totalPaid = Math.round(debts.reduce((s, d) => s + d.amount, 0) * 100) / 100;
+    const totalOwed = Math.round(
+      balances.filter((b) => b.net > 0).reduce((s, b) => s + b.net, 0) * 100
+    ) / 100;
+    expect(totalPaid).toBe(totalOwed);
+  });
+
+  it("ignores near-zero balances (floating-point noise below $0.01)", () => {
+    // A balance of $0.001 should not generate a payment.
+    const balances: Balance[] = [
+      { memberId: "alice", memberName: "alice", net: 0.001 },
+      { memberId: "bob", memberName: "bob", net: -0.001 },
+    ];
+    expect(simplifyDebts(balances)).toEqual([]);
+  });
+});

--- a/src/lib/__tests__/splits.test.ts
+++ b/src/lib/__tests__/splits.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from "vitest";
+import { computeSplits } from "../splits";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const ids = ["alice", "bob", "carol", "dave"];
+const amounts = (splits: ReturnType<typeof computeSplits>) => splits.map((s) => s.amount);
+const total = (splits: ReturnType<typeof computeSplits>) =>
+  Math.round(splits.reduce((s, x) => s + x.amount, 0) * 100) / 100;
+
+// ─── Equal split ─────────────────────────────────────────────────────────────
+// Business rule: each participant pays the same share.
+// When the amount doesn't divide evenly the LAST participant absorbs the
+// rounding remainder so splits always sum to exactly the expense total.
+
+describe("equal split", () => {
+  it("divides evenly when total divides cleanly", () => {
+    const splits = computeSplits("equal", 12, ["alice", "bob", "carol"], {});
+    expect(amounts(splits)).toEqual([4, 4, 4]);
+    expect(total(splits)).toBe(12);
+  });
+
+  it("gives the rounding remainder to the last participant", () => {
+    // $10 ÷ 3 = $3.33 repeating. First two pay $3.33, last pays $3.34.
+    const splits = computeSplits("equal", 10, ["alice", "bob", "carol"], {});
+    expect(amounts(splits)).toEqual([3.33, 3.33, 3.34]);
+    expect(total(splits)).toBe(10);
+  });
+
+  it("handles two participants", () => {
+    expect(amounts(computeSplits("equal", 9.99, ["alice", "bob"], {}))).toEqual([5, 4.99]);
+    expect(total(computeSplits("equal", 9.99, ["alice", "bob"], {}))).toBe(9.99);
+  });
+
+  it("handles a single participant (edge case: full amount)", () => {
+    const splits = computeSplits("equal", 42, ["alice"], {});
+    expect(amounts(splits)).toEqual([42]);
+  });
+
+  it("handles four participants with an amount that does not divide evenly", () => {
+    // $10 ÷ 4 = $2.50 each — divides exactly
+    expect(amounts(computeSplits("equal", 10, ids, {}))).toEqual([2.5, 2.5, 2.5, 2.5]);
+
+    // $11 ÷ 4 = $2.75 each — divides exactly
+    expect(amounts(computeSplits("equal", 11, ids, {}))).toEqual([2.75, 2.75, 2.75, 2.75]);
+
+    // $10.01 ÷ 4 = $2.5025 → rounds to $2.50 + $2.50 + $2.50 + $2.51
+    const splits = computeSplits("equal", 10.01, ids, {});
+    expect(amounts(splits)).toEqual([2.5, 2.5, 2.5, 2.51]);
+    expect(total(splits)).toBe(10.01);
+  });
+
+  it("always sums to the exact total for amounts with difficult rounding", () => {
+    const tricky = [0.1, 0.01, 1.99, 7.77, 99.99, 100.0];
+    const counts = [2, 3, 4, 5];
+    for (const amount of tricky) {
+      for (const n of counts) {
+        const participants = ids.slice(0, n);
+        const splits = computeSplits("equal", amount, participants, {});
+        expect(total(splits)).toBe(amount);
+      }
+    }
+  });
+
+  it("returns empty array when participant list is empty", () => {
+    expect(computeSplits("equal", 10, [], {})).toEqual([]);
+  });
+});
+
+// ─── Shares split ────────────────────────────────────────────────────────────
+// Business rule: each participant pays in proportion to their share weight.
+// E.g. weights 2:1 means the first person pays twice as much as the second.
+// The last participant absorbs any rounding remainder.
+
+describe("shares split", () => {
+  it("equal weights produce equal splits", () => {
+    const splits = computeSplits("shares", 12, ["alice", "bob", "carol"], {
+      shares: { alice: 1, bob: 1, carol: 1 },
+    });
+    expect(amounts(splits)).toEqual([4, 4, 4]);
+    expect(total(splits)).toBe(12);
+  });
+
+  it("2:1 weighting gives proportional amounts", () => {
+    // alice pays 2/3, bob pays 1/3
+    const splits = computeSplits("shares", 9, ["alice", "bob"], {
+      shares: { alice: 2, bob: 1 },
+    });
+    expect(amounts(splits)).toEqual([6, 3]);
+    expect(total(splits)).toBe(9);
+  });
+
+  it("last participant absorbs rounding remainder", () => {
+    // $10 with shares 1:1:1 → $3.33 + $3.33 + $3.34
+    const splits = computeSplits("shares", 10, ["alice", "bob", "carol"], {
+      shares: { alice: 1, bob: 1, carol: 1 },
+    });
+    expect(amounts(splits)).toEqual([3.33, 3.33, 3.34]);
+    expect(total(splits)).toBe(10);
+  });
+
+  it("handles non-integer weights (e.g. 2.5:1.5)", () => {
+    // alice: 2.5/4 * $10 = $6.25, bob: 1.5/4 * $10 = $3.75
+    const splits = computeSplits("shares", 10, ["alice", "bob"], {
+      shares: { alice: 2.5, bob: 1.5 },
+    });
+    expect(total(splits)).toBe(10);
+    expect(splits[0].amount).toBe(6.25);
+    expect(splits[1].amount).toBe(3.75);
+  });
+
+  it("returns empty array when all share weights are zero", () => {
+    // Prevents divide-by-zero; the caller should not submit this case.
+    const splits = computeSplits("shares", 10, ["alice", "bob"], {
+      shares: { alice: 0, bob: 0 },
+    });
+    expect(splits).toEqual([]);
+  });
+
+  it("missing weight for a participant defaults to zero", () => {
+    // If a participant has no share entry they contribute nothing to the
+    // weight total, so the entire amount goes to the participant with weight.
+    const splits = computeSplits("shares", 10, ["alice", "bob"], {
+      shares: { alice: 1 }, // bob has no entry → weight 0
+    });
+    expect(splits[0].amount).toBe(10);
+    expect(splits[1].amount).toBe(0);
+  });
+
+  it("always sums to the exact total", () => {
+    const splits = computeSplits("shares", 7.77, ["alice", "bob", "carol"], {
+      shares: { alice: 3, bob: 2, carol: 1 },
+    });
+    expect(total(splits)).toBe(7.77);
+  });
+});
+
+// ─── Percentage split ─────────────────────────────────────────────────────────
+// Business rule: each participant specifies what percentage of the total they
+// owe. Percentages should sum to 100 (validated client-side). The last
+// participant absorbs floating-point rounding from the others.
+
+describe("percentage split", () => {
+  it("50/50 split", () => {
+    const splits = computeSplits("percentage", 10, ["alice", "bob"], {
+      percentages: { alice: 50, bob: 50 },
+    });
+    expect(amounts(splits)).toEqual([5, 5]);
+    expect(total(splits)).toBe(10);
+  });
+
+  it("70/30 split", () => {
+    const splits = computeSplits("percentage", 15, ["alice", "bob"], {
+      percentages: { alice: 70, bob: 30 },
+    });
+    expect(amounts(splits)).toEqual([10.5, 4.5]);
+    expect(total(splits)).toBe(15);
+  });
+
+  it("33% / 33% / 34% approximates equal thirds", () => {
+    const splits = computeSplits("percentage", 10, ["alice", "bob", "carol"], {
+      percentages: { alice: 33, bob: 33, carol: 34 },
+    });
+    expect(amounts(splits)).toEqual([3.3, 3.3, 3.4]);
+    expect(total(splits)).toBe(10);
+  });
+
+  it("last participant absorbs the floating-point rounding from earlier splits", () => {
+    // 33.33% + 33.33% = 66.66% → alice $3.33, bob $3.33, carol gets remainder $3.34
+    const splits = computeSplits("percentage", 10, ["alice", "bob", "carol"], {
+      percentages: { alice: 33.33, bob: 33.33, carol: 33.34 },
+    });
+    expect(total(splits)).toBe(10);
+  });
+
+  it("always sums to the exact total", () => {
+    const splits = computeSplits("percentage", 99.99, ["alice", "bob", "carol", "dave"], {
+      percentages: { alice: 25, bob: 25, carol: 25, dave: 25 },
+    });
+    expect(total(splits)).toBe(99.99);
+  });
+});
+
+// ─── Exact split ─────────────────────────────────────────────────────────────
+// Business rule: each participant specifies their exact dollar amount.
+// This is a pure pass-through — the client form validates that the amounts
+// sum to the expense total before allowing submission.
+
+describe("exact split", () => {
+  it("passes through each participant's specified amount", () => {
+    const splits = computeSplits("exact", 10, ["alice", "bob"], {
+      exact: { alice: 7, bob: 3 },
+    });
+    expect(amounts(splits)).toEqual([7, 3]);
+  });
+
+  it("defaults to 0 when a participant has no entry", () => {
+    const splits = computeSplits("exact", 10, ["alice", "bob"], {
+      exact: { alice: 10 },
+    });
+    expect(splits[1].amount).toBe(0);
+  });
+});

--- a/src/lib/balances.ts
+++ b/src/lib/balances.ts
@@ -1,15 +1,19 @@
-import type { expenses, expenseSplits, members, settlements } from "@/db/schema";
+// Core accounting logic: member balances and debt simplification.
+//
+// Types use only the fields this module needs, keeping it decoupled from the
+// ORM layer and making unit tests straightforward — pass plain objects in,
+// get plain objects out. Drizzle's inferred types satisfy these interfaces
+// structurally, so no casting is needed at call sites.
 
-type Member = typeof members.$inferSelect;
-type Expense = typeof expenses.$inferSelect & {
-  splits: (typeof expenseSplits.$inferSelect)[];
-};
-type Settlement = typeof settlements.$inferSelect;
+export type Member = { id: string; name: string };
+export type ExpenseSplit = { memberId: string; amount: number };
+export type Expense = { amount: number; paidById: string; splits: ExpenseSplit[] };
+export type Settlement = { paidById: string; paidToId: string; amount: number };
 
 export type Balance = {
   memberId: string;
   memberName: string;
-  net: number; // positive = is owed money, negative = owes money
+  net: number; // positive = others owe you; negative = you owe others
 };
 
 export type SimplifiedDebt = {
@@ -20,36 +24,57 @@ export type SimplifiedDebt = {
   amount: number;
 };
 
+/**
+ * Compute each member's net balance across all expenses and settlements.
+ *
+ * Accounting model:
+ *   paying for an expense  → credits you the full amount
+ *   being in a split       → debits you your portion
+ *   recording a settlement → credits the payer, debits the recipient
+ *
+ * Money is conserved: the sum of all net balances is always zero.
+ */
 export function calculateBalances(
   groupMembers: Member[],
   groupExpenses: Expense[],
   groupSettlements: Settlement[]
 ): Balance[] {
-  const netMap = new Map<string, number>();
-  for (const m of groupMembers) netMap.set(m.id, 0);
+  const net = new Map<string, number>();
+  for (const m of groupMembers) net.set(m.id, 0);
 
-  for (const expense of groupExpenses) {
-    netMap.set(expense.paidById, (netMap.get(expense.paidById) ?? 0) + expense.amount);
-    for (const split of expense.splits) {
-      netMap.set(split.memberId, (netMap.get(split.memberId) ?? 0) - split.amount);
+  for (const e of groupExpenses) {
+    net.set(e.paidById, (net.get(e.paidById) ?? 0) + e.amount);
+    for (const s of e.splits) {
+      net.set(s.memberId, (net.get(s.memberId) ?? 0) - s.amount);
     }
   }
 
   for (const s of groupSettlements) {
-    netMap.set(s.paidById, (netMap.get(s.paidById) ?? 0) + s.amount);
-    netMap.set(s.paidToId, (netMap.get(s.paidToId) ?? 0) - s.amount);
+    net.set(s.paidById, (net.get(s.paidById) ?? 0) + s.amount);
+    net.set(s.paidToId, (net.get(s.paidToId) ?? 0) - s.amount);
   }
 
   const nameMap = new Map(groupMembers.map((m) => [m.id, m.name]));
-
-  return Array.from(netMap.entries()).map(([memberId, net]) => ({
-    memberId,
-    memberName: nameMap.get(memberId) ?? "Unknown",
-    net: Math.round(net * 100) / 100,
+  return Array.from(net.entries()).map(([id, amount]) => ({
+    memberId: id,
+    memberName: nameMap.get(id) ?? "Unknown",
+    net: Math.round(amount * 100) / 100,
   }));
 }
 
-// Greedy algorithm: minimises the number of transactions needed to settle up.
+/**
+ * Reduce balances to the minimum number of payments needed to settle all
+ * debts (greedy algorithm).
+ *
+ * Algorithm: sort creditors (net > 0) and debtors (net < 0) by absolute
+ * value descending. Greedily match each debtor against the largest creditor,
+ * paying min(debtor's debt, creditor's credit). Advance whichever side
+ * reaches zero.
+ *
+ * This greedy approach doesn't guarantee the globally optimal solution
+ * (which is NP-hard in general) but minimises transactions for the vast
+ * majority of real-world groups of ≤ 20 people.
+ */
 export function simplifyDebts(balances: Balance[]): SimplifiedDebt[] {
   const creditors = balances
     .filter((b) => b.net > 0.01)
@@ -61,7 +86,7 @@ export function simplifyDebts(balances: Balance[]): SimplifiedDebt[] {
     .map((b) => ({ ...b, remaining: b.net }))
     .sort((a, b) => a.remaining - b.remaining);
 
-  const transactions: SimplifiedDebt[] = [];
+  const result: SimplifiedDebt[] = [];
   let i = 0;
   let j = 0;
 
@@ -71,7 +96,7 @@ export function simplifyDebts(balances: Balance[]): SimplifiedDebt[] {
     const amount = Math.round(Math.min(-debtor.remaining, creditor.remaining) * 100) / 100;
 
     if (amount > 0) {
-      transactions.push({
+      result.push({
         fromId: debtor.memberId,
         fromName: debtor.memberName,
         toId: creditor.memberId,
@@ -87,5 +112,5 @@ export function simplifyDebts(balances: Balance[]): SimplifiedDebt[] {
     if (Math.abs(creditor.remaining) < 0.01) j++;
   }
 
-  return transactions;
+  return result;
 }

--- a/src/lib/splits.ts
+++ b/src/lib/splits.ts
@@ -1,0 +1,78 @@
+// Business logic for dividing an expense amount among participants.
+// Kept separate from server actions so it can be unit-tested without a
+// database, HTTP context, or browser APIs (FormData).
+
+export type SplitEntry = { memberId: string; amount: number };
+export type SplitType = "equal" | "shares" | "percentage" | "exact";
+
+// Per-participant values keyed by member ID.
+// Only the fields relevant to the chosen SplitType need to be populated.
+export type SplitInputs = {
+  shares?: Record<string, number>;       // relative weight per participant
+  percentages?: Record<string, number>;  // 0–100 per participant
+  exact?: Record<string, number>;        // explicit dollar amount per participant
+};
+
+const r2 = (n: number) => Math.round(n * 100) / 100;
+
+/**
+ * Compute per-participant split amounts for an expense.
+ *
+ * Rounding rule (equal / shares / percentage): amounts are rounded to
+ * 2 decimal places; the LAST participant in the list absorbs any remainder
+ * so the splits always sum to exactly `amount`. This prevents a $0.01 gap
+ * when dividing amounts that don't divide evenly (e.g. $10 ÷ 3).
+ *
+ * "exact" mode is a pure pass-through — the caller (client form) is
+ * responsible for validating that the entered amounts sum to the total.
+ *
+ * "percentage" mode uses the same last-person rule to handle floating-point
+ * noise. The caller must validate that percentages sum to 100 before saving.
+ */
+export function computeSplits(
+  splitType: SplitType,
+  amount: number,
+  participantIds: string[],
+  inputs: SplitInputs = {}
+): SplitEntry[] {
+  const n = participantIds.length;
+  if (n === 0) return [];
+
+  if (splitType === "equal") {
+    const perPerson = r2(amount / n);
+    let allocated = 0;
+    return participantIds.map((id, i) => {
+      const a = i < n - 1 ? perPerson : r2(amount - allocated);
+      if (i < n - 1) allocated = r2(allocated + a);
+      return { memberId: id, amount: a };
+    });
+  }
+
+  if (splitType === "shares") {
+    const weights = participantIds.map((id) => inputs.shares?.[id] ?? 0);
+    const totalWeight = weights.reduce((s, w) => s + w, 0);
+    if (totalWeight === 0) return [];
+    let allocated = 0;
+    return participantIds.map((id, i) => {
+      const a = i < n - 1 ? r2((amount * weights[i]) / totalWeight) : r2(amount - allocated);
+      if (i < n - 1) allocated = r2(allocated + a);
+      return { memberId: id, amount: a };
+    });
+  }
+
+  if (splitType === "percentage") {
+    let allocated = 0;
+    return participantIds.map((id, i) => {
+      const pct = inputs.percentages?.[id] ?? 0;
+      const a = i < n - 1 ? r2((amount * pct) / 100) : r2(amount - allocated);
+      if (i < n - 1) allocated = r2(allocated + a);
+      return { memberId: id, amount: a };
+    });
+  }
+
+  // "exact": caller provides the exact dollar amount per participant.
+  return participantIds.map((id) => ({
+    memberId: id,
+    amount: inputs.exact?.[id] ?? 0,
+  }));
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import path from "path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+});


### PR DESCRIPTION
Bug fix:
- Delete group button had an onClick handler inside a server component, crashing the /groups/[id] page on load. Moved to DeleteGroupButton client component.

Refactors (enable testing):
- computeSplits extracted from actions.ts → src/lib/splits.ts with plain SplitInputs type (no FormData dependency) so it can be unit-tested.
- balances.ts rewritten with plain Member/Expense/Settlement interfaces decoupled from Drizzle types — structural compatibility preserved.
- actions.ts parses FormData into SplitInputs and delegates to splits.ts.

Tests (35 passing):
- splits.test.ts: equal/shares/percentage/exact modes, rounding behaviour, edge cases, sum-invariant property across tricky amounts.
- balances.test.ts: credit/debit accounting, multi-expense accumulation, settlements, conservation-of-money invariant, debt simplification (chain collapse, multiple creditors/debtors, floating-point noise).

https://claude.ai/code/session_01JoiBxyk23YSrUU29NjNxaD