### PR TITLE
feat: E2E tests, unit tests, payer-gets-higher-cent rounding rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,13 @@ local.db-wal
 # drizzle migrations (optional to commit)
 drizzle/
 
+# playwright
+playwright-report/
+test-results/
+e2e-test.db
+e2e-test.db-shm
+e2e-test.db-wal
+
 # misc
 .DS_Store
 *.pem

--- a/e2e/expenses.spec.ts
+++ b/e2e/expenses.spec.ts
@@ -1,0 +1,108 @@
+import { test, expect } from "@playwright/test";
+import { createTestGroup, fillExpenseBase } from "./helpers";
+
+// Tests the full expense-entry flow: form submission with all four split
+// modes, correct balance display, and expense deletion.
+//
+// Balance math is verified end-to-end here (form → server action → DB →
+// calculateBalances → UI) as a complement to the unit tests in
+// src/lib/__tests__/splits.test.ts and balances.test.ts.
+
+test.describe("Adding expenses – equal split", () => {
+  test("$10 split equally between two people shows +$5 / −$5", async ({ page }) => {
+    const id = await createTestGroup(page, "E2E Equal 2", ["Alice", "Bob"]);
+    await fillExpenseBase(page, id, { description: "Dinner", amount: "10", paidBy: "Alice" });
+    await page.getByRole("button", { name: "Add Expense" }).click();
+
+    await expect(page).toHaveURL(`/groups/${id}`);
+    await expect(page.getByText("+$5.00")).toBeVisible();
+    await expect(page.getByText("-$5.00")).toBeVisible();
+  });
+
+  test("payer gets the higher cent when $10 splits 3 ways ($3.34 not $3.33)", async ({ page }) => {
+    // Rounding rule: Alice paid → Alice owes $3.34, others $3.33 each.
+    const id = await createTestGroup(page, "E2E Equal 3", ["Alice", "Bob", "Carol"]);
+    await fillExpenseBase(page, id, { description: "Lunch", amount: "10", paidBy: "Alice" });
+    await page.getByRole("button", { name: "Add Expense" }).click();
+
+    // Expense card should show the per-person splits
+    await expect(page.getByText("Alice: $3.34")).toBeVisible();
+    await expect(page.getByText("Bob: $3.33")).toBeVisible();
+    await expect(page.getByText("Carol: $3.33")).toBeVisible();
+  });
+
+  test("expense appears in the list with payer and amount", async ({ page }) => {
+    const id = await createTestGroup(page, "E2E List", ["Alice", "Bob"]);
+    await fillExpenseBase(page, id, { description: "Hotel", amount: "120", paidBy: "Alice" });
+    await page.getByRole("button", { name: "Add Expense" }).click();
+
+    await expect(page.getByText("Hotel")).toBeVisible();
+    await expect(page.getByText("$120.00")).toBeVisible();
+    await expect(page.getByText(/Paid by Alice/)).toBeVisible();
+  });
+
+  test("can delete an expense and balances reset to zero", async ({ page }) => {
+    const id = await createTestGroup(page, "E2E Delete", ["Alice", "Bob"]);
+    await fillExpenseBase(page, id, { description: "Coffee", amount: "5", paidBy: "Alice" });
+    await page.getByRole("button", { name: "Add Expense" }).click();
+
+    // Delete the expense using the × button
+    await page.locator("button[title='Delete expense']").click();
+
+    // No expenses left — balances should show settled up
+    await expect(page.getByText("All settled up!")).toBeVisible();
+  });
+});
+
+test.describe("Adding expenses – shares split", () => {
+  test("2:1 shares correctly allocates twice as much to the payer", async ({ page }) => {
+    // Alice (payer) has 2 shares, Bob has 1 share. Total $9.
+    // Alice owes $6, Bob owes $3.
+    const id = await createTestGroup(page, "E2E Shares", ["Alice", "Bob"]);
+    await fillExpenseBase(page, id, { description: "Groceries", amount: "9", paidBy: "Alice" });
+
+    await page.getByRole("button", { name: "Shares" }).click();
+    // The inputs are named share_<uuid> — target by position (Alice=first, Bob=second)
+    await page.locator("input[name^='share_']").first().fill("2");
+    await page.locator("input[name^='share_']").last().fill("1");
+
+    await page.getByRole("button", { name: "Add Expense" }).click();
+
+    await expect(page.getByText("Alice: $6.00")).toBeVisible();
+    await expect(page.getByText("Bob: $3.00")).toBeVisible();
+    // Alice paid $9 and owes $6 → net +$3
+    await expect(page.getByText("+$3.00")).toBeVisible();
+  });
+});
+
+test.describe("Adding expenses – percentage split", () => {
+  test("70% / 30% split produces correct amounts", async ({ page }) => {
+    const id = await createTestGroup(page, "E2E Pct", ["Alice", "Bob"]);
+    await fillExpenseBase(page, id, { description: "Concert", amount: "40", paidBy: "Alice" });
+
+    await page.getByRole("button", { name: "%" }).click();
+    await page.locator("input[name^='pct_']").first().fill("70");
+    await page.locator("input[name^='pct_']").last().fill("30");
+
+    await page.getByRole("button", { name: "Add Expense" }).click();
+
+    await expect(page.getByText("Alice: $28.00")).toBeVisible();
+    await expect(page.getByText("Bob: $12.00")).toBeVisible();
+  });
+});
+
+test.describe("Adding expenses – exact split", () => {
+  test("exact amounts are stored and displayed as entered", async ({ page }) => {
+    const id = await createTestGroup(page, "E2E Exact", ["Alice", "Bob"]);
+    await fillExpenseBase(page, id, { description: "Taxi", amount: "17.50", paidBy: "Alice" });
+
+    await page.getByRole("button", { name: "Exact" }).click();
+    await page.locator("input[name^='exact_']").first().fill("10");
+    await page.locator("input[name^='exact_']").last().fill("7.50");
+
+    await page.getByRole("button", { name: "Add Expense" }).click();
+
+    await expect(page.getByText("Alice: $10.00")).toBeVisible();
+    await expect(page.getByText("Bob: $7.50")).toBeVisible();
+  });
+});

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,15 @@
+import { execSync } from "child_process";
+import { existsSync, unlinkSync } from "fs";
+
+// Runs once before all E2E tests. Wipes any leftover test database and
+// pushes the current schema so every run starts from a clean slate.
+export default async function globalSetup() {
+  for (const file of ["e2e-test.db", "e2e-test.db-shm", "e2e-test.db-wal"]) {
+    if (existsSync(file)) unlinkSync(file);
+  }
+
+  execSync("npm run db:push", {
+    stdio: "inherit",
+    env: { ...process.env, TURSO_DATABASE_URL: "file:e2e-test.db" },
+  });
+}

--- a/e2e/groups.spec.ts
+++ b/e2e/groups.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from "@playwright/test";
+import { createTestGroup } from "./helpers";
+
+// Tests the full lifecycle of groups: creation, listing, member management,
+// navigation, and deletion. Each test creates its own group so tests are
+// independent and can be run in any order within this file.
+
+test.describe("Group management", () => {
+  test("shows empty state on first visit", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByText("No groups yet")).toBeVisible();
+    await expect(page.getByRole("link", { name: /Create your first group/i })).toBeVisible();
+  });
+
+  test("user can create a group and land on the group page", async ({ page }) => {
+    await page.goto("/groups/new");
+    await page.getByPlaceholder("e.g. Tokyo Trip, Apartment").fill("Weekend Cabin");
+    await page.getByPlaceholder("Member 1").fill("Alice");
+    await page.getByPlaceholder("Member 2").fill("Bob");
+
+    await page.getByRole("button", { name: "Create Group" }).click();
+
+    await expect(page).toHaveURL(/\/groups\/[^/]+$/);
+    await expect(page.getByRole("heading", { name: "Weekend Cabin" })).toBeVisible();
+    await expect(page.getByText("2 members")).toBeVisible();
+  });
+
+  test("new group appears on the home page", async ({ page }) => {
+    await createTestGroup(page, "Barcelona Trip", ["Maria", "Carlos"]);
+
+    await page.goto("/");
+    await expect(page.getByRole("link", { name: /Barcelona Trip/i })).toBeVisible();
+    await expect(page.getByText("2 members")).toBeVisible();
+  });
+
+  test("can add more members to an existing group", async ({ page }) => {
+    await createTestGroup(page, "Dinner Club", ["Alice", "Bob"]);
+
+    await page.getByPlaceholder("Add a member…").fill("Carol");
+    await page.getByRole("button", { name: "Add" }).click();
+
+    await expect(page.getByText("3 members")).toBeVisible();
+    // Carol should appear in the members list
+    await expect(page.getByText("Carol")).toBeVisible();
+  });
+
+  test("can navigate back to home from a group page", async ({ page }) => {
+    await createTestGroup(page, "Road Trip", ["Alice", "Bob"]);
+
+    await page.getByRole("link", { name: "← Groups" }).click();
+    await expect(page).toHaveURL("/");
+  });
+
+  test("can create a group with more than two members", async ({ page }) => {
+    await page.goto("/groups/new");
+    await page.getByPlaceholder("e.g. Tokyo Trip, Apartment").fill("Big Group");
+    await page.getByPlaceholder("Member 1").fill("Alice");
+    await page.getByPlaceholder("Member 2").fill("Bob");
+
+    await page.getByRole("button", { name: /Add another member/i }).click();
+    await page.getByPlaceholder("Member 3").fill("Carol");
+    await page.getByRole("button", { name: /Add another member/i }).click();
+    await page.getByPlaceholder("Member 4").fill("Dave");
+
+    await page.getByRole("button", { name: "Create Group" }).click();
+    await expect(page).toHaveURL(/\/groups\/[^/]+$/);
+    await expect(page.getByText("4 members")).toBeVisible();
+  });
+});

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,0 +1,42 @@
+import { type Page } from "@playwright/test";
+
+// Creates a group via the UI and returns the group ID extracted from the URL.
+export async function createTestGroup(
+  page: Page,
+  name: string,
+  memberNames: string[]
+): Promise<string> {
+  await page.goto("/groups/new");
+  await page.getByPlaceholder("e.g. Tokyo Trip, Apartment").fill(name);
+
+  const existing = page.getByPlaceholder(/Member \d+/);
+  const preRendered = await existing.count();
+
+  for (let i = 0; i < memberNames.length; i++) {
+    if (i < preRendered) {
+      await existing.nth(i).fill(memberNames[i]);
+    } else {
+      await page.getByRole("button", { name: /Add another member/ }).click();
+      await page.getByPlaceholder(/Member \d+/).last().fill(memberNames[i]);
+    }
+  }
+
+  await page.getByRole("button", { name: "Create Group" }).click();
+  await page.waitForURL(/\/groups\/[^/]+$/);
+  return page.url().split("/").pop()!;
+}
+
+// Navigates to the add-expense form and fills in the basic fields.
+// Returns without submitting so the caller can customise the split.
+export async function fillExpenseBase(
+  page: Page,
+  groupId: string,
+  opts: { description: string; amount: string; paidBy?: string }
+) {
+  await page.goto(`/groups/${groupId}/expenses/new`);
+  await page.getByPlaceholder("e.g. Dinner, Hotel, Uber").fill(opts.description);
+  await page.getByPlaceholder("0.00").fill(opts.amount);
+  if (opts.paidBy) {
+    await page.getByRole("combobox", { name: /Paid by/i }).selectOption({ label: opts.paidBy });
+  }
+}

--- a/e2e/settle.spec.ts
+++ b/e2e/settle.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from "@playwright/test";
+import { createTestGroup, fillExpenseBase } from "./helpers";
+
+// Tests the full settle-up flow: suggested payments after expenses are added,
+// marking debts as settled, recording manual payments, and the history log.
+
+test.describe("Settle up", () => {
+  test("suggested payment shows correct amount after an expense", async ({ page }) => {
+    // Alice pays $10, split equally → Bob owes Alice $5.
+    const id = await createTestGroup(page, "E2E Settle Basic", ["Alice", "Bob"]);
+    await fillExpenseBase(page, id, { description: "Dinner", amount: "10", paidBy: "Alice" });
+    await page.getByRole("button", { name: "Add Expense" }).click();
+
+    await page.getByRole("link", { name: /Settle up/i }).click();
+    await expect(page).toHaveURL(`/groups/${id}/settle`);
+
+    // Suggested payment: Bob pays Alice $5
+    await expect(page.getByText("Bob")).toBeVisible();
+    await expect(page.getByText("Alice")).toBeVisible();
+    await expect(page.getByText("$5.00")).toBeVisible();
+  });
+
+  test("marking a debt as settled zeros out all balances", async ({ page }) => {
+    const id = await createTestGroup(page, "E2E Settle Zero", ["Alice", "Bob"]);
+    await fillExpenseBase(page, id, { description: "Drinks", amount: "20", paidBy: "Alice" });
+    await page.getByRole("button", { name: "Add Expense" }).click();
+
+    await page.getByRole("link", { name: /Settle up/i }).click();
+    await page.getByRole("button", { name: "Mark as Settled" }).click();
+
+    // After settling, the page should show all clear
+    await expect(page.getByText("All settled up!")).toBeVisible();
+
+    // Group page should also show settled status
+    await page.goto(`/groups/${id}`);
+    await expect(page.getByText("✓ All settled up!")).toBeVisible();
+  });
+
+  test("simplified debts collapse a chain A→B→C into a single A→C payment", async ({ page }) => {
+    // Expense 1: Alice pays $10 → Alice +$5, Bob -$5
+    // Expense 2: Bob pays $10  → Bob +$5, Carol -$5
+    // Net: Alice +$5, Bob $0, Carol -$5 → simplified: Carol pays Alice $5 directly.
+    const id = await createTestGroup(page, "E2E Simplify", ["Alice", "Bob", "Carol"]);
+
+    await fillExpenseBase(page, id, { description: "E1", amount: "10", paidBy: "Alice" });
+    // Exclude Carol from first expense (Alice and Bob only)
+    await page.locator("button.w-5.h-5.rounded").nth(2).click(); // uncheck Carol
+    await page.getByRole("button", { name: "Add Expense" }).click();
+
+    await fillExpenseBase(page, id, { description: "E2", amount: "10", paidBy: "Bob" });
+    // Exclude Alice from second expense (Bob and Carol only)
+    await page.locator("button.w-5.h-5.rounded").nth(0).click(); // uncheck Alice
+    await page.getByRole("button", { name: "Add Expense" }).click();
+
+    await page.goto(`/groups/${id}/settle`);
+    // Should show exactly one suggested payment: Carol → Alice $5
+    await expect(page.getByText("Carol")).toBeVisible();
+    await expect(page.getByText("$5.00")).toBeVisible();
+  });
+
+  test("manual payment is recorded and appears in history", async ({ page }) => {
+    const id = await createTestGroup(page, "E2E History", ["Alice", "Bob"]);
+    await fillExpenseBase(page, id, { description: "Lunch", amount: "30", paidBy: "Alice" });
+    await page.getByRole("button", { name: "Add Expense" }).click();
+
+    await page.goto(`/groups/${id}/settle`);
+
+    // Record a manual payment via the "Record a Payment" form
+    await page.locator("select[name='paidById']").last().selectOption({ label: "Bob" });
+    await page.locator("select[name='paidToId']").last().selectOption({ label: "Alice" });
+    await page.locator("input[name='amount']").last().fill("15");
+    await page.locator("input[name='note']").fill("Venmo");
+    await page.getByRole("button", { name: "Record Payment" }).click();
+
+    await expect(page.getByText("Venmo")).toBeVisible();
+    await expect(page.getByText("$15.00")).toBeVisible();
+  });
+
+  test("can delete a settlement record", async ({ page }) => {
+    const id = await createTestGroup(page, "E2E Delete Settlement", ["Alice", "Bob"]);
+    await fillExpenseBase(page, id, { description: "Taxi", amount: "10", paidBy: "Alice" });
+    await page.getByRole("button", { name: "Add Expense" }).click();
+
+    await page.goto(`/groups/${id}/settle`);
+    await page.getByRole("button", { name: "Mark as Settled" }).click();
+
+    // Settlement appears in history — delete it
+    await page.locator("button[title='Delete record']").click();
+
+    // Debt should reappear now that settlement is removed
+    await expect(page.getByText("Mark as Settled")).toBeVisible();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "tailwind-merge": "^2.5.4"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -2030,6 +2031,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -6712,6 +6729,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -12,29 +12,32 @@
     "db:studio": "drizzle-kit studio",
     "vercel-build": "npm run db:push && npm run build",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
+    "@libsql/client": "^0.14.0",
+    "clsx": "^2.1.1",
+    "drizzle-orm": "^0.38.0",
+    "lucide-react": "^0.468.0",
     "next": "^15.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "@libsql/client": "^0.14.0",
-    "drizzle-orm": "^0.38.0",
-    "lucide-react": "^0.468.0",
-    "clsx": "^2.1.1",
     "tailwind-merge": "^2.5.4"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "typescript": "^5",
-    "eslint": "^9",
-    "eslint-config-next": "^15.1.0",
-    "tailwindcss": "^3.4.1",
-    "postcss": "^8",
     "autoprefixer": "^10.0.1",
     "drizzle-kit": "^0.29.0",
+    "eslint": "^9",
+    "eslint-config-next": "^15.1.0",
+    "postcss": "^8",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5",
     "vitest": "^3.0.0"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,43 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// E2E tests run against a dedicated SQLite file that is wiped and recreated
+// before every test run (see e2e/global-setup.ts). Tests run sequentially
+// (workers: 1) because SQLite cannot safely handle concurrent writes.
+
+export default defineConfig({
+  testDir: "./e2e",
+  workers: 1,
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: [["html", { open: "never" }], ["line"]],
+  globalSetup: "./e2e/global-setup.ts",
+
+  use: {
+    baseURL: "http://localhost:3001",
+    trace: "on-first-retry",
+  },
+
+  projects: [
+    {
+      name: "Desktop Chrome",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "iPhone 14",
+      use: { ...devices["iPhone 14"] },
+    },
+  ],
+
+  webServer: {
+    // Start Next.js on port 3001 so it doesn't conflict with the dev server.
+    // TURSO_DATABASE_URL points at the dedicated test DB created by global-setup.
+    command: "npm run dev -- -p 3001",
+    url: "http://localhost:3001",
+    reuseExistingServer: false,
+    timeout: 60_000,
+    env: {
+      TURSO_DATABASE_URL: "file:e2e-test.db",
+    },
+  },
+});

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -84,7 +84,7 @@ export async function createExpense(groupId: string, formData: FormData) {
     ),
   };
 
-  const splits = computeSplits(splitType, Math.round(amount * 100) / 100, participantIds, inputs);
+  const splits = computeSplits(splitType, Math.round(amount * 100) / 100, participantIds, inputs, paidById);
   if (splits.length === 0) return;
 
   const expenseId = generateId();

--- a/src/app/groups/[id]/expenses/new/expense-form.tsx
+++ b/src/app/groups/[id]/expenses/new/expense-form.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { createExpense } from "@/app/actions";
+import { computeSplits } from "@/lib/splits";
 import { formatCurrency, today } from "@/lib/format";
 
 type Member = { id: string; name: string };
@@ -9,6 +10,7 @@ type SplitType = "equal" | "shares" | "percentage" | "exact";
 
 export function ExpenseForm({ groupId, members }: { groupId: string; members: Member[] }) {
   const [amount, setAmount] = useState("");
+  const [paidById, setPaidById] = useState(members[0]?.id ?? "");
   const [splitType, setSplitType] = useState<SplitType>("equal");
   const [participants, setParticipants] = useState<Set<string>>(
     new Set(members.map((m) => m.id))
@@ -40,52 +42,20 @@ export function ExpenseForm({ groupId, members }: { groupId: string; members: Me
 
   const splits = useMemo(() => {
     if (numericAmount <= 0 || participantList.length === 0) return [];
-    const count = participantList.length;
-
-    if (splitType === "equal") {
-      const base = Math.round((numericAmount / count) * 100) / 100;
-      let remaining = numericAmount;
-      return participantList.map((m, i) => {
-        const a = i === count - 1 ? Math.round(remaining * 100) / 100 : base;
-        remaining -= base;
-        return { memberId: m.id, name: m.name, amount: a };
-      });
-    }
-
-    if (splitType === "shares") {
-      const shareNums = participantList.map((m) => parseFloat(shareValues[m.id]) || 0);
-      const totalShares = shareNums.reduce((s, n) => s + n, 0);
-      if (totalShares === 0) return [];
-      let remaining = numericAmount;
-      return participantList.map((m, i) => {
-        const a =
-          i === count - 1
-            ? Math.round(remaining * 100) / 100
-            : Math.round(((numericAmount * shareNums[i]) / totalShares) * 100) / 100;
-        remaining -= i === count - 1 ? 0 : a;
-        return { memberId: m.id, name: m.name, amount: a };
-      });
-    }
-
-    if (splitType === "percentage") {
-      let remaining = numericAmount;
-      return participantList.map((m, i) => {
-        const pct = parseFloat(pctValues[m.id]) || 0;
-        const a =
-          i === count - 1
-            ? Math.round(remaining * 100) / 100
-            : Math.round(((numericAmount * pct) / 100) * 100) / 100;
-        remaining -= i === count - 1 ? 0 : a;
-        return { memberId: m.id, name: m.name, amount: a };
-      });
-    }
-
-    return participantList.map((m) => ({
-      memberId: m.id,
-      name: m.name,
-      amount: parseFloat(exactValues[m.id]) || 0,
-    }));
-  }, [splitType, numericAmount, participantList, shareValues, pctValues, exactValues]);
+    const ids = participantList.map((m) => m.id);
+    const entries = computeSplits(
+      splitType,
+      numericAmount,
+      ids,
+      {
+        shares: Object.fromEntries(ids.map((id) => [id, parseFloat(shareValues[id]) || 0])),
+        percentages: Object.fromEntries(ids.map((id) => [id, parseFloat(pctValues[id]) || 0])),
+        exact: Object.fromEntries(ids.map((id) => [id, parseFloat(exactValues[id]) || 0])),
+      },
+      paidById
+    );
+    return entries.map((e, i) => ({ ...e, name: participantList[i].name }));
+  }, [splitType, numericAmount, participantList, shareValues, pctValues, exactValues, paidById]);
 
   const splitTotal = splits.reduce((s, x) => s + x.amount, 0);
   const pctTotal = participantList.reduce((s, m) => s + (parseFloat(pctValues[m.id]) || 0), 0);
@@ -148,6 +118,8 @@ export function ExpenseForm({ groupId, members }: { groupId: string; members: Me
         <select
           name="paidById"
           required
+          value={paidById}
+          onChange={(e) => setPaidById(e.target.value)}
           className="w-full border border-slate-300 rounded-lg px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-transparent bg-white"
         >
           {members.map((m) => (

--- a/src/lib/__tests__/splits.test.ts
+++ b/src/lib/__tests__/splits.test.ts
@@ -3,201 +3,211 @@ import { computeSplits } from "../splits";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-const ids = ["alice", "bob", "carol", "dave"];
 const amounts = (splits: ReturnType<typeof computeSplits>) => splits.map((s) => s.amount);
 const total = (splits: ReturnType<typeof computeSplits>) =>
   Math.round(splits.reduce((s, x) => s + x.amount, 0) * 100) / 100;
 
-// ─── Equal split ─────────────────────────────────────────────────────────────
-// Business rule: each participant pays the same share.
-// When the amount doesn't divide evenly the LAST participant absorbs the
-// rounding remainder so splits always sum to exactly the expense total.
+// ─── Rounding rule ────────────────────────────────────────────────────────────
+// When an amount doesn't divide evenly, one participant absorbs the $0.01
+// remainder. That participant is the PAYER (if they are in the split), so the
+// person who laid out the money is made whole to the nearest cent. If the
+// payer is not a participant, the last participant in the list gets it.
 
-describe("equal split", () => {
-  it("divides evenly when total divides cleanly", () => {
-    const splits = computeSplits("equal", 12, ["alice", "bob", "carol"], {});
-    expect(amounts(splits)).toEqual([4, 4, 4]);
-    expect(total(splits)).toBe(12);
+describe("rounding remainder assignment", () => {
+  it("gives the remainder to the payer when they are in the split", () => {
+    // $10 ÷ 3 = $3.33 repeating. Alice paid, so Alice gets $3.34.
+    const splits = computeSplits("equal", 10, ["alice", "bob", "carol"], {}, "alice");
+    expect(amounts(splits)).toEqual([3.34, 3.33, 3.33]);
+    expect(total(splits)).toBe(10);
   });
 
-  it("gives the rounding remainder to the last participant", () => {
-    // $10 ÷ 3 = $3.33 repeating. First two pay $3.33, last pays $3.34.
-    const splits = computeSplits("equal", 10, ["alice", "bob", "carol"], {});
+  it("gives the remainder to the payer even if they are not first in the list", () => {
+    const splits = computeSplits("equal", 10, ["alice", "bob", "carol"], {}, "bob");
+    expect(amounts(splits)).toEqual([3.33, 3.34, 3.33]);
+    expect(total(splits)).toBe(10);
+  });
+
+  it("falls back to last participant when payer is not in the split", () => {
+    // Dave paid but is not sharing in the split — last participant (carol) gets remainder.
+    const splits = computeSplits("equal", 10, ["alice", "bob", "carol"], {}, "dave");
     expect(amounts(splits)).toEqual([3.33, 3.33, 3.34]);
     expect(total(splits)).toBe(10);
   });
 
+  it("falls back to last participant when no payer is supplied", () => {
+    const splits = computeSplits("equal", 10, ["alice", "bob", "carol"]);
+    expect(amounts(splits)).toEqual([3.33, 3.33, 3.34]);
+    expect(total(splits)).toBe(10);
+  });
+});
+
+// ─── Equal split ─────────────────────────────────────────────────────────────
+// Each participant pays an equal share. The payer absorbs any rounding
+// remainder so splits always sum to exactly the expense total.
+
+describe("equal split", () => {
+  it("divides evenly when total divides cleanly", () => {
+    const splits = computeSplits("equal", 12, ["alice", "bob", "carol"], {}, "alice");
+    expect(amounts(splits)).toEqual([4, 4, 4]);
+    expect(total(splits)).toBe(12);
+  });
+
+  it("payer gets the rounding remainder ($3.34, others get $3.33)", () => {
+    const splits = computeSplits("equal", 10, ["alice", "bob", "carol"], {}, "alice");
+    expect(amounts(splits)).toEqual([3.34, 3.33, 3.33]);
+    expect(total(splits)).toBe(10);
+  });
+
   it("handles two participants", () => {
-    expect(amounts(computeSplits("equal", 9.99, ["alice", "bob"], {}))).toEqual([5, 4.99]);
-    expect(total(computeSplits("equal", 9.99, ["alice", "bob"], {}))).toBe(9.99);
+    const splits = computeSplits("equal", 9.99, ["alice", "bob"], {}, "alice");
+    expect(amounts(splits)).toEqual([5, 4.99]);
+    expect(total(splits)).toBe(9.99);
   });
 
-  it("handles a single participant (edge case: full amount)", () => {
-    const splits = computeSplits("equal", 42, ["alice"], {});
-    expect(amounts(splits)).toEqual([42]);
-  });
-
-  it("handles four participants with an amount that does not divide evenly", () => {
-    // $10 ÷ 4 = $2.50 each — divides exactly
-    expect(amounts(computeSplits("equal", 10, ids, {}))).toEqual([2.5, 2.5, 2.5, 2.5]);
-
-    // $11 ÷ 4 = $2.75 each — divides exactly
-    expect(amounts(computeSplits("equal", 11, ids, {}))).toEqual([2.75, 2.75, 2.75, 2.75]);
-
-    // $10.01 ÷ 4 = $2.5025 → rounds to $2.50 + $2.50 + $2.50 + $2.51
-    const splits = computeSplits("equal", 10.01, ids, {});
-    expect(amounts(splits)).toEqual([2.5, 2.5, 2.5, 2.51]);
-    expect(total(splits)).toBe(10.01);
+  it("handles a single participant (full amount to that person)", () => {
+    expect(amounts(computeSplits("equal", 42, ["alice"], {}, "alice"))).toEqual([42]);
   });
 
   it("always sums to the exact total for amounts with difficult rounding", () => {
     const tricky = [0.1, 0.01, 1.99, 7.77, 99.99, 100.0];
     const counts = [2, 3, 4, 5];
+    const ids = ["alice", "bob", "carol", "dave", "eve"];
     for (const amount of tricky) {
       for (const n of counts) {
         const participants = ids.slice(0, n);
-        const splits = computeSplits("equal", amount, participants, {});
-        expect(total(splits)).toBe(amount);
+        expect(total(computeSplits("equal", amount, participants, {}, "alice"))).toBe(amount);
       }
     }
   });
 
-  it("returns empty array when participant list is empty", () => {
+  it("returns empty array for an empty participant list", () => {
     expect(computeSplits("equal", 10, [], {})).toEqual([]);
   });
 });
 
 // ─── Shares split ────────────────────────────────────────────────────────────
-// Business rule: each participant pays in proportion to their share weight.
+// Each participant pays in proportion to their relative share weight.
 // E.g. weights 2:1 means the first person pays twice as much as the second.
-// The last participant absorbs any rounding remainder.
 
 describe("shares split", () => {
   it("equal weights produce equal splits", () => {
-    const splits = computeSplits("shares", 12, ["alice", "bob", "carol"], {
-      shares: { alice: 1, bob: 1, carol: 1 },
-    });
+    const splits = computeSplits(
+      "shares", 12, ["alice", "bob", "carol"],
+      { shares: { alice: 1, bob: 1, carol: 1 } },
+      "alice"
+    );
     expect(amounts(splits)).toEqual([4, 4, 4]);
     expect(total(splits)).toBe(12);
   });
 
-  it("2:1 weighting gives proportional amounts", () => {
-    // alice pays 2/3, bob pays 1/3
-    const splits = computeSplits("shares", 9, ["alice", "bob"], {
-      shares: { alice: 2, bob: 1 },
-    });
+  it("2:1 weighting — first person pays twice as much", () => {
+    const splits = computeSplits(
+      "shares", 9, ["alice", "bob"],
+      { shares: { alice: 2, bob: 1 } },
+      "alice"
+    );
     expect(amounts(splits)).toEqual([6, 3]);
     expect(total(splits)).toBe(9);
   });
 
-  it("last participant absorbs rounding remainder", () => {
-    // $10 with shares 1:1:1 → $3.33 + $3.33 + $3.34
-    const splits = computeSplits("shares", 10, ["alice", "bob", "carol"], {
-      shares: { alice: 1, bob: 1, carol: 1 },
-    });
-    expect(amounts(splits)).toEqual([3.33, 3.33, 3.34]);
+  it("payer absorbs rounding remainder with 1:1:1 shares on $10", () => {
+    // alice paid → alice gets $3.34
+    const splits = computeSplits(
+      "shares", 10, ["alice", "bob", "carol"],
+      { shares: { alice: 1, bob: 1, carol: 1 } },
+      "alice"
+    );
+    expect(amounts(splits)).toEqual([3.34, 3.33, 3.33]);
     expect(total(splits)).toBe(10);
   });
 
-  it("handles non-integer weights (e.g. 2.5:1.5)", () => {
-    // alice: 2.5/4 * $10 = $6.25, bob: 1.5/4 * $10 = $3.75
-    const splits = computeSplits("shares", 10, ["alice", "bob"], {
-      shares: { alice: 2.5, bob: 1.5 },
-    });
+  it("handles non-integer weights (2.5:1.5)", () => {
+    const splits = computeSplits(
+      "shares", 10, ["alice", "bob"],
+      { shares: { alice: 2.5, bob: 1.5 } },
+      "alice"
+    );
     expect(total(splits)).toBe(10);
     expect(splits[0].amount).toBe(6.25);
     expect(splits[1].amount).toBe(3.75);
   });
 
-  it("returns empty array when all share weights are zero", () => {
-    // Prevents divide-by-zero; the caller should not submit this case.
-    const splits = computeSplits("shares", 10, ["alice", "bob"], {
-      shares: { alice: 0, bob: 0 },
-    });
-    expect(splits).toEqual([]);
-  });
-
-  it("missing weight for a participant defaults to zero", () => {
-    // If a participant has no share entry they contribute nothing to the
-    // weight total, so the entire amount goes to the participant with weight.
-    const splits = computeSplits("shares", 10, ["alice", "bob"], {
-      shares: { alice: 1 }, // bob has no entry → weight 0
-    });
-    expect(splits[0].amount).toBe(10);
-    expect(splits[1].amount).toBe(0);
+  it("returns empty array when all share weights are zero (prevents divide-by-zero)", () => {
+    expect(
+      computeSplits("shares", 10, ["alice", "bob"], { shares: { alice: 0, bob: 0 } })
+    ).toEqual([]);
   });
 
   it("always sums to the exact total", () => {
-    const splits = computeSplits("shares", 7.77, ["alice", "bob", "carol"], {
-      shares: { alice: 3, bob: 2, carol: 1 },
-    });
+    const splits = computeSplits(
+      "shares", 7.77, ["alice", "bob", "carol"],
+      { shares: { alice: 3, bob: 2, carol: 1 } },
+      "carol"
+    );
     expect(total(splits)).toBe(7.77);
   });
 });
 
 // ─── Percentage split ─────────────────────────────────────────────────────────
-// Business rule: each participant specifies what percentage of the total they
-// owe. Percentages should sum to 100 (validated client-side). The last
-// participant absorbs floating-point rounding from the others.
+// Each participant specifies what percentage of the total they owe.
+// Percentages must sum to 100 (validated on the client before submission).
 
 describe("percentage split", () => {
   it("50/50 split", () => {
-    const splits = computeSplits("percentage", 10, ["alice", "bob"], {
-      percentages: { alice: 50, bob: 50 },
-    });
+    const splits = computeSplits(
+      "percentage", 10, ["alice", "bob"],
+      { percentages: { alice: 50, bob: 50 } },
+      "alice"
+    );
     expect(amounts(splits)).toEqual([5, 5]);
-    expect(total(splits)).toBe(10);
   });
 
   it("70/30 split", () => {
-    const splits = computeSplits("percentage", 15, ["alice", "bob"], {
-      percentages: { alice: 70, bob: 30 },
-    });
+    const splits = computeSplits(
+      "percentage", 15, ["alice", "bob"],
+      { percentages: { alice: 70, bob: 30 } },
+      "alice"
+    );
     expect(amounts(splits)).toEqual([10.5, 4.5]);
-    expect(total(splits)).toBe(15);
   });
 
-  it("33% / 33% / 34% approximates equal thirds", () => {
-    const splits = computeSplits("percentage", 10, ["alice", "bob", "carol"], {
-      percentages: { alice: 33, bob: 33, carol: 34 },
-    });
+  it("33% / 33% / 34% — payer at index 0 gets the remainder", () => {
+    const splits = computeSplits(
+      "percentage", 10, ["alice", "bob", "carol"],
+      { percentages: { alice: 33, bob: 33, carol: 34 } },
+      "alice"
+    );
+    expect(total(splits)).toBe(10);
+    // alice's 33% = $3.30, bob's 33% = $3.30, carol's 34% = $3.40
+    // sum = $10.00 — no remainder needed here
     expect(amounts(splits)).toEqual([3.3, 3.3, 3.4]);
-    expect(total(splits)).toBe(10);
-  });
-
-  it("last participant absorbs the floating-point rounding from earlier splits", () => {
-    // 33.33% + 33.33% = 66.66% → alice $3.33, bob $3.33, carol gets remainder $3.34
-    const splits = computeSplits("percentage", 10, ["alice", "bob", "carol"], {
-      percentages: { alice: 33.33, bob: 33.33, carol: 33.34 },
-    });
-    expect(total(splits)).toBe(10);
   });
 
   it("always sums to the exact total", () => {
-    const splits = computeSplits("percentage", 99.99, ["alice", "bob", "carol", "dave"], {
-      percentages: { alice: 25, bob: 25, carol: 25, dave: 25 },
-    });
+    const splits = computeSplits(
+      "percentage", 99.99, ["alice", "bob", "carol", "dave"],
+      { percentages: { alice: 25, bob: 25, carol: 25, dave: 25 } },
+      "bob"
+    );
     expect(total(splits)).toBe(99.99);
   });
 });
 
 // ─── Exact split ─────────────────────────────────────────────────────────────
-// Business rule: each participant specifies their exact dollar amount.
-// This is a pure pass-through — the client form validates that the amounts
-// sum to the expense total before allowing submission.
+// Each participant specifies their exact dollar amount. Pure pass-through —
+// the client form validates that amounts sum to the total before submitting.
 
 describe("exact split", () => {
-  it("passes through each participant's specified amount", () => {
-    const splits = computeSplits("exact", 10, ["alice", "bob"], {
-      exact: { alice: 7, bob: 3 },
-    });
+  it("passes through each participant's specified amount unchanged", () => {
+    const splits = computeSplits(
+      "exact", 10, ["alice", "bob"],
+      { exact: { alice: 7, bob: 3 } }
+    );
     expect(amounts(splits)).toEqual([7, 3]);
   });
 
-  it("defaults to 0 when a participant has no entry", () => {
-    const splits = computeSplits("exact", 10, ["alice", "bob"], {
-      exact: { alice: 10 },
-    });
+  it("defaults to 0 for participants with no entry", () => {
+    const splits = computeSplits("exact", 10, ["alice", "bob"], { exact: { alice: 10 } });
     expect(splits[1].amount).toBe(0);
   });
 });

--- a/src/lib/splits.ts
+++ b/src/lib/splits.ts
@@ -18,59 +18,80 @@ const r2 = (n: number) => Math.round(n * 100) / 100;
 /**
  * Compute per-participant split amounts for an expense.
  *
- * Rounding rule (equal / shares / percentage): amounts are rounded to
- * 2 decimal places; the LAST participant in the list absorbs any remainder
- * so the splits always sum to exactly `amount`. This prevents a $0.01 gap
- * when dividing amounts that don't divide evenly (e.g. $10 ÷ 3).
+ * Rounding rule: amounts are rounded to 2 decimal places. One participant
+ * absorbs the remainder so splits always sum to exactly `amount`.
  *
- * "exact" mode is a pure pass-through — the caller (client form) is
- * responsible for validating that the entered amounts sum to the total.
+ * Remainder assignment (equal / shares / percentage modes):
+ *   - If the payer (payerId) is in the participant list they receive the
+ *     remainder, giving them the slightly higher share. This makes the
+ *     person who laid out the money whole to the nearest cent.
+ *   - If the payer is not a participant, the last participant gets it.
  *
- * "percentage" mode uses the same last-person rule to handle floating-point
- * noise. The caller must validate that percentages sum to 100 before saving.
+ * "exact" mode is a pure pass-through — the caller is responsible for
+ * validating that the entered amounts sum to the total.
  */
 export function computeSplits(
   splitType: SplitType,
   amount: number,
   participantIds: string[],
-  inputs: SplitInputs = {}
+  inputs: SplitInputs = {},
+  payerId?: string
 ): SplitEntry[] {
   const n = participantIds.length;
   if (n === 0) return [];
 
+  const payerIdx =
+    payerId !== undefined && participantIds.includes(payerId)
+      ? participantIds.indexOf(payerId)
+      : n - 1;
+
+  // Distribute any rounding gap (in whole cents) so the payer is never
+  // shortchanged:
+  //   +N cents remaining → payer gets the first extra cent, then others
+  //   -N cents remaining → non-payers absorb the discount first, payer last
+  //
+  // Working in integer cents avoids floating-point accumulation errors.
+  const applyRemainder = (base: number[]): number[] => {
+    const amountCents = Math.round(amount * 100);
+    const cents = base.map((a) => Math.round(a * 100));
+    const diff = amountCents - cents.reduce((s, c) => s + c, 0);
+    if (diff === 0) return base;
+
+    const step = diff > 0 ? 1 : -1;
+    const result = [...cents];
+    const order =
+      diff > 0
+        ? [payerIdx, ...Array.from({ length: n }, (_, i) => i).filter((i) => i !== payerIdx)]
+        : [...Array.from({ length: n }, (_, i) => i).filter((i) => i !== payerIdx), payerIdx];
+
+    for (let i = 0; i < Math.abs(diff) && i < order.length; i++) {
+      result[order[i]] += step;
+    }
+    return result.map((c) => c / 100);
+  };
+
   if (splitType === "equal") {
     const perPerson = r2(amount / n);
-    let allocated = 0;
-    return participantIds.map((id, i) => {
-      const a = i < n - 1 ? perPerson : r2(amount - allocated);
-      if (i < n - 1) allocated = r2(allocated + a);
-      return { memberId: id, amount: a };
-    });
+    const amounts = applyRemainder(new Array<number>(n).fill(perPerson));
+    return participantIds.map((id, i) => ({ memberId: id, amount: amounts[i] }));
   }
 
   if (splitType === "shares") {
     const weights = participantIds.map((id) => inputs.shares?.[id] ?? 0);
     const totalWeight = weights.reduce((s, w) => s + w, 0);
     if (totalWeight === 0) return [];
-    let allocated = 0;
-    return participantIds.map((id, i) => {
-      const a = i < n - 1 ? r2((amount * weights[i]) / totalWeight) : r2(amount - allocated);
-      if (i < n - 1) allocated = r2(allocated + a);
-      return { memberId: id, amount: a };
-    });
+    const base = weights.map((w) => r2((amount * w) / totalWeight));
+    const amounts = applyRemainder(base);
+    return participantIds.map((id, i) => ({ memberId: id, amount: amounts[i] }));
   }
 
   if (splitType === "percentage") {
-    let allocated = 0;
-    return participantIds.map((id, i) => {
-      const pct = inputs.percentages?.[id] ?? 0;
-      const a = i < n - 1 ? r2((amount * pct) / 100) : r2(amount - allocated);
-      if (i < n - 1) allocated = r2(allocated + a);
-      return { memberId: id, amount: a };
-    });
+    const base = participantIds.map((id) => r2(((inputs.percentages?.[id] ?? 0) * amount) / 100));
+    const amounts = applyRemainder(base);
+    return participantIds.map((id, i) => ({ memberId: id, amount: amounts[i] }));
   }
 
-  // "exact": caller provides the exact dollar amount per participant.
+  // "exact": caller provides the dollar amount for each participant.
   return participantIds.map((id) => ({
     memberId: id,
     amount: inputs.exact?.[id] ?? 0,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
+    include: ["src/**/*.test.ts"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

- **Payer-gets-higher-cent rounding rule**: When a split doesn't divide evenly, the expense payer always receives the extra cent rather than it falling to the last person in the list. Implemented in integer-cent arithmetic to avoid float accumulation.
- **Unit tests (36 passing)**: `src/lib/__tests__/splits.test.ts` (22 tests covering all 4 split modes + rounding) and `src/lib/__tests__/balances.test.ts` (14 tests covering balance calculation, debt simplification, conservation law). Tests follow the "code as context" principle — descriptions document business rules.
- **E2E tests with Playwright**: Full browser tests for the golden paths across groups, expenses (all 4 split modes), and settle-up flow. Uses a dedicated `e2e-test.db` with per-run teardown so tests are isolated.

## Test plan

- [ ] Run unit tests: `npm test` — all 36 should pass
- [ ] Install Playwright browsers: `npx playwright install chromium`
- [ ] Run E2E tests: `npm run test:e2e` — covers group creation, all split modes, settle-up, manual payments, deletion
- [ ] Verify rounding: add a $10 expense split 3 ways — Alice (payer) shows $3.34, Bob and Carol each $3.33

https://claude.ai/code/session_01JoiBxyk23YSrUU29NjNxaD

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoiBxyk23YSrUU29NjNxaD)_