### PR TITLE
[codex] add settle-up ledger history

### DIFF
--- a/drizzle/0001_sloppy_mac_gargan.sql
+++ b/drizzle/0001_sloppy_mac_gargan.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `expense_revisions` (
+	`id` text PRIMARY KEY NOT NULL,
+	`expense_id` text NOT NULL,
+	`before_snapshot` text NOT NULL,
+	`after_snapshot` text NOT NULL,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	FOREIGN KEY (`expense_id`) REFERENCES `expenses`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+ALTER TABLE `settlements` ADD `reversal_of_settlement_id` text REFERENCES settlements(id);

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,449 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "33aa2f5d-6a7d-4422-b509-71849de0875f",
+  "prevId": "957805f0-e3af-4939-8874-23576d3ce88a",
+  "tables": {
+    "expense_revisions": {
+      "name": "expense_revisions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expense_id": {
+          "name": "expense_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "before_snapshot": {
+          "name": "before_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "after_snapshot": {
+          "name": "after_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "expense_revisions_expense_id_expenses_id_fk": {
+          "name": "expense_revisions_expense_id_expenses_id_fk",
+          "tableFrom": "expense_revisions",
+          "tableTo": "expenses",
+          "columnsFrom": [
+            "expense_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "expense_splits": {
+      "name": "expense_splits",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expense_id": {
+          "name": "expense_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "expense_splits_expense_id_expenses_id_fk": {
+          "name": "expense_splits_expense_id_expenses_id_fk",
+          "tableFrom": "expense_splits",
+          "tableTo": "expenses",
+          "columnsFrom": [
+            "expense_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "expense_splits_member_id_members_id_fk": {
+          "name": "expense_splits_member_id_members_id_fk",
+          "tableFrom": "expense_splits",
+          "tableTo": "members",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "expenses": {
+      "name": "expenses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "paid_by_id": {
+          "name": "paid_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "split_type": {
+          "name": "split_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "expenses_group_id_groups_id_fk": {
+          "name": "expenses_group_id_groups_id_fk",
+          "tableFrom": "expenses",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "expenses_paid_by_id_members_id_fk": {
+          "name": "expenses_paid_by_id_members_id_fk",
+          "tableFrom": "expenses",
+          "tableTo": "members",
+          "columnsFrom": [
+            "paid_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "groups": {
+      "name": "groups",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "members": {
+      "name": "members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "members_group_id_groups_id_fk": {
+          "name": "members_group_id_groups_id_fk",
+          "tableFrom": "members",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settlements": {
+      "name": "settlements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "paid_by_id": {
+          "name": "paid_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "paid_to_id": {
+          "name": "paid_to_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reversal_of_settlement_id": {
+          "name": "reversal_of_settlement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "settlements_group_id_groups_id_fk": {
+          "name": "settlements_group_id_groups_id_fk",
+          "tableFrom": "settlements",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "settlements_paid_by_id_members_id_fk": {
+          "name": "settlements_paid_by_id_members_id_fk",
+          "tableFrom": "settlements",
+          "tableTo": "members",
+          "columnsFrom": [
+            "paid_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "settlements_paid_to_id_members_id_fk": {
+          "name": "settlements_paid_to_id_members_id_fk",
+          "tableFrom": "settlements",
+          "tableTo": "members",
+          "columnsFrom": [
+            "paid_to_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "settlements_reversal_of_settlement_id_settlements_id_fk": {
+          "name": "settlements_reversal_of_settlement_id_settlements_id_fk",
+          "tableFrom": "settlements",
+          "tableTo": "settlements",
+          "columnsFrom": [
+            "reversal_of_settlement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1777125742483,
       "tag": "0000_bored_starjammers",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1777219566768,
+      "tag": "0001_sloppy_mac_gargan",
+      "breakpoints": true
     }
   ]
 }

--- a/e2e/00-empty-state.spec.ts
+++ b/e2e/00-empty-state.spec.ts
@@ -2,6 +2,9 @@ import { test, expect } from "@playwright/test";
 
 // Must run before any other spec creates groups in the DB.
 // Named 00-* so it sorts before expenses.spec.ts alphabetically.
+
+test.skip(({ isMobile }) => isMobile, "Desktop run already verifies the clean shared DB state.");
+
 test("shows empty state on first visit", async ({ page }) => {
   await page.goto("/");
   await expect(page.getByText("No groups yet")).toBeVisible();

--- a/e2e/settle.spec.ts
+++ b/e2e/settle.spec.ts
@@ -83,7 +83,59 @@ test.describe("Settle up", () => {
     await expect(page.getByText("$15.00")).toBeVisible();
   });
 
-  test("can delete a settlement record", async ({ page }) => {
+  test("editing a settled expense reopens balances and shows a warning on settle up", async ({ page }) => {
+    const id = await createTestGroup(page, "E2E Reopen Debt", ["Alice", "Bob"]);
+    await fillExpenseBase(page, id, { description: "Museum", amount: "10", paidBy: "Alice" });
+    await page.getByRole("button", { name: "Add Expense" }).click();
+
+    await page.goto(`/groups/${id}/settle`);
+    await page.getByRole("button", { name: "Mark as Settled" }).click();
+    await expect(page.getByText("All settled up!")).toBeVisible();
+
+    await page.goto(`/groups/${id}`);
+    await page.locator("a[title='Edit expense']").click();
+    await page.getByPlaceholder("0.00").first().fill("20");
+    await page.getByRole("button", { name: "Save Changes" }).click();
+
+    await expect(page.getByText("Bob owes Alice")).toBeVisible();
+
+    await page.goto(`/groups/${id}/settle`);
+    await expect(
+      page.getByText("Payments remain in your history, but edited expenses reopened the current ledger.")
+    ).toBeVisible();
+  });
+
+  test("editing a split after settlement adds an expense-edited activity entry", async ({ page }) => {
+    const id = await createTestGroup(page, "E2E Split Activity", ["Alice", "Bob", "Carol"]);
+    await fillExpenseBase(page, id, { description: "Boat", amount: "30", paidBy: "Alice" });
+    await page.getByRole("button", { name: "Exact" }).click();
+    await page.locator("input[name^='exact_']").nth(0).fill("10");
+    await page.locator("input[name^='exact_']").nth(1).fill("10");
+    await page.locator("input[name^='exact_']").nth(2).fill("10");
+    await page.getByRole("button", { name: "Add Expense" }).click();
+
+    await page.goto(`/groups/${id}/settle`);
+    await page.getByRole("button", { name: "Mark as Settled" }).nth(0).click();
+    await page.getByRole("button", { name: "Mark as Settled" }).nth(0).click();
+    await expect(page.getByText("All settled up!")).toBeVisible();
+
+    await page.goto(`/groups/${id}`);
+    await page.locator("a[title='Edit expense']").click();
+    await page.locator("input[name^='exact_']").nth(0).fill("0");
+    await page.locator("input[name^='exact_']").nth(1).fill("15");
+    await page.locator("input[name^='exact_']").nth(2).fill("15");
+    await page.getByRole("button", { name: "Save Changes" }).click();
+
+    const activitySection = page
+      .locator("section")
+      .filter({ has: page.getByRole("heading", { name: "Activity", exact: true }) });
+
+    await expect(activitySection.getByRole("heading", { name: "Activity", exact: true })).toBeVisible();
+    await expect(activitySection.getByText("Expense edited")).toBeVisible();
+    await expect(activitySection.getByText("Boat").first()).toBeVisible();
+  });
+
+  test("can reverse a settlement record without erasing the original payment", async ({ page }) => {
     const id = await createTestGroup(page, "E2E Delete Settlement", ["Alice", "Bob"]);
     await fillExpenseBase(page, id, { description: "Taxi", amount: "10", paidBy: "Alice" });
     await page.getByRole("button", { name: "Add Expense" }).click();
@@ -93,9 +145,11 @@ test.describe("Settle up", () => {
 
     // Accept the confirmation dialog that appears before deletion
     page.on("dialog", (dialog) => dialog.accept());
-    await page.locator("button[title='Delete record']").click();
+    await page.getByRole("button", { name: "Reverse payment" }).click();
 
-    // Debt should reappear now that settlement is removed
+    await expect(page.getByText("Payment recorded")).toBeVisible();
+    await expect(page.getByText("Payment reversed")).toBeVisible();
+    await expect(page.getByText("Reversal of payment")).toBeVisible();
     await expect(page.getByText("Mark as Settled")).toBeVisible();
   });
 });

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1,17 +1,20 @@
 "use server";
 
-import { eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 
 import { db } from "@/db";
 import {
+  expenseRevisions,
   expenseSplits,
   expenses,
   groups,
   members,
   settlements,
 } from "@/db/schema";
+import { formatDate, today } from "@/lib/format";
+import { createExpenseSnapshot, serializeExpenseSnapshot } from "@/lib/history";
 import { computeSplits, type SplitInputs, type SplitType } from "@/lib/splits";
 import { generateId } from "@/lib/utils";
 
@@ -139,19 +142,54 @@ export async function updateExpense(groupId: string, expenseId: string, formData
   const splits = computeSplits(splitType, Math.round(amount * 100) / 100, participantIds, inputs, paidById);
   if (splits.length === 0) return;
 
-  await db.update(expenses).set({
-    description,
-    amount: Math.round(amount * 100) / 100,
-    paidById,
-    splitType,
-    date,
-  }).where(eq(expenses.id, expenseId));
+  const [existingExpense, existingSplits] = await Promise.all([
+    db.query.expenses.findFirst({
+      where: and(eq(expenses.id, expenseId), eq(expenses.groupId, groupId)),
+    }),
+    db.select().from(expenseSplits).where(eq(expenseSplits.expenseId, expenseId)),
+  ]);
+  if (!existingExpense) return;
 
-  await db.delete(expenseSplits).where(eq(expenseSplits.expenseId, expenseId));
-
-  await db.insert(expenseSplits).values(
-    splits.map((s) => ({ id: generateId(), expenseId, ...s }))
+  const roundedAmount = Math.round(amount * 100) / 100;
+  const beforeSnapshot = serializeExpenseSnapshot(
+    createExpenseSnapshot(existingExpense, existingSplits)
   );
+  const afterSnapshot = serializeExpenseSnapshot(
+    createExpenseSnapshot(
+      {
+        description,
+        amount: roundedAmount,
+        paidById,
+        splitType,
+        date,
+      },
+      splits
+    )
+  );
+
+  await db.transaction(async (tx) => {
+    await tx
+      .update(expenses)
+      .set({
+        description,
+        amount: roundedAmount,
+        paidById,
+        splitType,
+        date,
+      })
+      .where(eq(expenses.id, expenseId));
+
+    await tx.delete(expenseSplits).where(eq(expenseSplits.expenseId, expenseId));
+
+    await tx.insert(expenseSplits).values(splits.map((s) => ({ id: generateId(), expenseId, ...s })));
+
+    await tx.insert(expenseRevisions).values({
+      id: generateId(),
+      expenseId,
+      beforeSnapshot,
+      afterSnapshot,
+    });
+  });
 
   revalidatePath(`/groups/${groupId}`);
   redirect(`/groups/${groupId}`);
@@ -182,6 +220,7 @@ export async function createSettlement(groupId: string, formData: FormData) {
     paidToId,
     amount: Math.round(amount * 100) / 100,
     note,
+    reversalOfSettlementId: null,
     date,
   });
 
@@ -189,8 +228,32 @@ export async function createSettlement(groupId: string, formData: FormData) {
   redirect(`/groups/${groupId}/settle`);
 }
 
-export async function deleteSettlement(groupId: string, settlementId: string) {
-  await db.delete(settlements).where(eq(settlements.id, settlementId));
+export async function reverseSettlement(groupId: string, settlementId: string) {
+  const original = await db.query.settlements.findFirst({
+    where: and(
+      eq(settlements.id, settlementId),
+      eq(settlements.groupId, groupId),
+      isNull(settlements.reversalOfSettlementId)
+    ),
+  });
+  if (!original) return;
+
+  const existingReversal = await db.query.settlements.findFirst({
+    where: eq(settlements.reversalOfSettlementId, settlementId),
+  });
+  if (existingReversal) return;
+
+  await db.insert(settlements).values({
+    id: generateId(),
+    groupId,
+    paidById: original.paidToId,
+    paidToId: original.paidById,
+    amount: original.amount,
+    note: `Reversal of payment from ${formatDate(original.date)}`,
+    reversalOfSettlementId: original.id,
+    date: today(),
+  });
+
   revalidatePath(`/groups/${groupId}/settle`);
   redirect(`/groups/${groupId}/settle`);
 }

--- a/src/app/groups/[id]/page.tsx
+++ b/src/app/groups/[id]/page.tsx
@@ -3,15 +3,22 @@ import Link from "next/link";
 
 export const dynamic = "force-dynamic";
 import { Plus, ArrowRight, Pencil } from "lucide-react";
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 
 import { db } from "@/db";
-import { expenses, expenseSplits, groups, members, settlements } from "@/db/schema";
+import { expenseRevisions, expenseSplits, expenses, groups, members, settlements } from "@/db/schema";
 import { calculateBalances, simplifyDebts } from "@/lib/balances";
 import { formatCurrency, formatDate } from "@/lib/format";
+import { buildActivityEvents, getPostSettlementEditedExpenseIds } from "@/lib/history";
 import { addMember, deleteExpense } from "@/app/actions";
 import { DeleteGroupButton } from "./delete-group-button";
 import { ConfirmDeleteButton } from "./confirm-delete-button";
+
+type MemberRow = typeof members.$inferSelect;
+type ExpenseRow = typeof expenses.$inferSelect;
+type SettlementRow = typeof settlements.$inferSelect;
+type ExpenseSplitRow = typeof expenseSplits.$inferSelect;
+type ExpenseRevisionRow = typeof expenseRevisions.$inferSelect;
 
 export default async function GroupPage({
   params,
@@ -23,7 +30,11 @@ export default async function GroupPage({
   const group = await db.query.groups.findFirst({ where: eq(groups.id, id) });
   if (!group) notFound();
 
-  const [groupMembers, groupExpenses, groupSettlements] = await Promise.all([
+  const [groupMembers, groupExpenses, groupSettlements]: [
+    MemberRow[],
+    ExpenseRow[],
+    SettlementRow[],
+  ] = await Promise.all([
     db.select().from(members).where(eq(members.groupId, id)),
     db
       .select()
@@ -33,20 +44,56 @@ export default async function GroupPage({
     db.select().from(settlements).where(eq(settlements.groupId, id)),
   ]);
 
-  const expensesWithSplits = await Promise.all(
-    groupExpenses.map(async (e) => ({
-      ...e,
-      splits: await db
-        .select()
-        .from(expenseSplits)
-        .where(eq(expenseSplits.expenseId, e.id)),
-    }))
-  );
+  const expenseIds = groupExpenses.map((expense) => expense.id);
+  const [groupExpenseSplits, groupExpenseRevisions]: [ExpenseSplitRow[], ExpenseRevisionRow[]] =
+    await Promise.all([
+    expenseIds.length > 0
+      ? db.select().from(expenseSplits).where(inArray(expenseSplits.expenseId, expenseIds))
+      : Promise.resolve([] as ExpenseSplitRow[]),
+    expenseIds.length > 0
+      ? db.select().from(expenseRevisions).where(inArray(expenseRevisions.expenseId, expenseIds))
+      : Promise.resolve([] as ExpenseRevisionRow[]),
+    ]);
+
+  const splitsByExpenseId = new Map<string, ExpenseSplitRow[]>();
+  for (const split of groupExpenseSplits) {
+    const existing = splitsByExpenseId.get(split.expenseId);
+    if (existing) {
+      existing.push(split);
+    } else {
+      splitsByExpenseId.set(split.expenseId, [split]);
+    }
+  }
+
+  const revisionsByExpenseId = new Map<string, ExpenseRevisionRow[]>();
+  for (const revision of groupExpenseRevisions) {
+    const existing = revisionsByExpenseId.get(revision.expenseId);
+    if (existing) {
+      existing.push(revision);
+    } else {
+      revisionsByExpenseId.set(revision.expenseId, [revision]);
+    }
+  }
+
+  const expensesWithSplits = groupExpenses.map((expense) => ({
+    ...expense,
+    splits: splitsByExpenseId.get(expense.id) ?? [],
+  }));
 
   const balances = calculateBalances(groupMembers, expensesWithSplits, groupSettlements);
   const debts = simplifyDebts(balances);
   const memberMap = new Map(groupMembers.map((m) => [m.id, m.name]));
   const totalSpend = groupExpenses.reduce((s, e) => s + e.amount, 0);
+  const editedExpenseIds = new Set(groupExpenseRevisions.map((revision) => revision.expenseId));
+  const postSettlementEditedExpenseIds = getPostSettlementEditedExpenseIds(
+    groupExpenseRevisions,
+    groupSettlements
+  );
+  const activityEvents = buildActivityEvents({
+    expenses: groupExpenses,
+    revisions: groupExpenseRevisions,
+    settlements: groupSettlements,
+  });
 
   const addMemberAction = addMember.bind(null, id);
 
@@ -152,7 +199,19 @@ export default async function GroupPage({
               >
                 <div className="flex items-start justify-between gap-3">
                   <div className="flex-1 min-w-0">
-                    <p className="font-medium text-slate-900 truncate">{expense.description}</p>
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <p className="font-medium text-slate-900 truncate">{expense.description}</p>
+                      {editedExpenseIds.has(expense.id) && (
+                        <span className="text-[11px] font-medium bg-slate-100 text-slate-600 px-2 py-0.5 rounded-full">
+                          Edited
+                        </span>
+                      )}
+                      {postSettlementEditedExpenseIds.has(expense.id) && (
+                        <span className="text-[11px] font-medium bg-amber-100 text-amber-800 px-2 py-0.5 rounded-full">
+                          Edited after payments were recorded
+                        </span>
+                      )}
+                    </div>
                     <p className="text-xs text-slate-400 mt-0.5">
                       Paid by {memberMap.get(expense.paidById)} · {formatDate(expense.date)}
                     </p>
@@ -188,6 +247,93 @@ export default async function GroupPage({
                     </ConfirmDeleteButton>
                   </div>
                 </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Activity */}
+      <section>
+        <h2 className="font-semibold text-slate-900 mb-1">Activity</h2>
+        <p className="text-sm text-slate-500 mb-3">
+          Payments stay in history even if older expenses are edited later. If the current
+          ledger shows debt again, record another payment.
+        </p>
+        {activityEvents.length === 0 ? (
+          <div className="text-center py-10 border-2 border-dashed border-slate-200 rounded-xl">
+            <p className="text-slate-400 text-sm">No activity yet</p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {activityEvents.map((event) => (
+              <div
+                key={event.id}
+                className="bg-white rounded-xl border border-slate-200 px-4 py-3 space-y-1"
+              >
+                {event.type === "expense_created" && (
+                  <>
+                    <p className="text-sm font-medium text-slate-900">
+                      Expense added: {event.expense.description}
+                    </p>
+                    <p className="text-sm text-slate-600">
+                      {memberMap.get(event.expense.paidById)} paid{" "}
+                      <span className="font-semibold">{formatCurrency(event.expense.amount)}</span>
+                    </p>
+                    <p className="text-xs text-slate-400">{formatDate(event.expense.date)}</p>
+                  </>
+                )}
+                {event.type === "expense_edited" && (
+                  <>
+                    <p className="text-sm font-medium text-slate-900">Expense edited</p>
+                    <p className="text-sm text-slate-700">{event.after.description}</p>
+                    <p className="text-xs text-slate-500">
+                      {formatCurrency(event.before.amount)} → {formatCurrency(event.after.amount)}
+                    </p>
+                    <p className="text-xs text-slate-400">
+                      {formatDate(event.after.date)}
+                      {event.before.description !== event.after.description
+                        ? ` · renamed from ${event.before.description}`
+                        : ""}
+                    </p>
+                  </>
+                )}
+                {event.type === "settlement_recorded" && (
+                  <>
+                    <p className="text-sm font-medium text-slate-900">Payment recorded</p>
+                    <p className="text-sm text-slate-600">
+                      <span className="font-semibold">{memberMap.get(event.paidById)}</span>
+                      <span className="text-slate-500"> paid </span>
+                      <span className="font-semibold">{memberMap.get(event.paidToId)}</span>
+                      <span className="font-semibold text-green-600">
+                        {" "}
+                        {formatCurrency(event.amount)}
+                      </span>
+                    </p>
+                    <p className="text-xs text-slate-400">
+                      {formatDate(event.date)}
+                      {event.note ? ` · ${event.note}` : ""}
+                    </p>
+                  </>
+                )}
+                {event.type === "settlement_reversed" && (
+                  <>
+                    <p className="text-sm font-medium text-slate-900">Payment reversed</p>
+                    <p className="text-sm text-slate-600">
+                      <span className="font-semibold">{memberMap.get(event.paidById)}</span>
+                      <span className="text-slate-500"> paid </span>
+                      <span className="font-semibold">{memberMap.get(event.paidToId)}</span>
+                      <span className="font-semibold text-amber-700">
+                        {" "}
+                        {formatCurrency(event.amount)}
+                      </span>
+                    </p>
+                    <p className="text-xs text-slate-400">
+                      {formatDate(event.date)}
+                      {event.note ? ` · ${event.note}` : ""}
+                    </p>
+                  </>
+                )}
               </div>
             ))}
           </div>

--- a/src/app/groups/[id]/settle/page.tsx
+++ b/src/app/groups/[id]/settle/page.tsx
@@ -1,15 +1,22 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 
 export const dynamic = "force-dynamic";
 
 import { db } from "@/db";
-import { expenses, expenseSplits, groups, members, settlements } from "@/db/schema";
+import { expenseRevisions, expenseSplits, expenses, groups, members, settlements } from "@/db/schema";
 import { calculateBalances, simplifyDebts } from "@/lib/balances";
 import { formatCurrency, formatDate, today } from "@/lib/format";
-import { createSettlement, deleteSettlement } from "@/app/actions";
+import { hasExpenseEditsAfterSettlementStarted } from "@/lib/history";
+import { createSettlement, reverseSettlement } from "@/app/actions";
 import { ConfirmDeleteButton } from "../confirm-delete-button";
+
+type MemberRow = typeof members.$inferSelect;
+type ExpenseRow = typeof expenses.$inferSelect;
+type SettlementRow = typeof settlements.$inferSelect;
+type ExpenseSplitRow = typeof expenseSplits.$inferSelect;
+type ExpenseRevisionRow = typeof expenseRevisions.$inferSelect;
 
 export default async function SettlePage({
   params,
@@ -21,7 +28,11 @@ export default async function SettlePage({
   const group = await db.query.groups.findFirst({ where: eq(groups.id, id) });
   if (!group) notFound();
 
-  const [groupMembers, groupExpenses, groupSettlements] = await Promise.all([
+  const [groupMembers, groupExpenses, groupSettlements]: [
+    MemberRow[],
+    ExpenseRow[],
+    SettlementRow[],
+  ] = await Promise.all([
     db.select().from(members).where(eq(members.groupId, id)),
     db.select().from(expenses).where(eq(expenses.groupId, id)),
     db
@@ -31,19 +42,46 @@ export default async function SettlePage({
       .orderBy(settlements.date),
   ]);
 
-  const expensesWithSplits = await Promise.all(
-    groupExpenses.map(async (e) => ({
-      ...e,
-      splits: await db
-        .select()
-        .from(expenseSplits)
-        .where(eq(expenseSplits.expenseId, e.id)),
-    }))
-  );
+  const expenseIds = groupExpenses.map((expense) => expense.id);
+  const [groupExpenseSplits, groupExpenseRevisions]: [ExpenseSplitRow[], ExpenseRevisionRow[]] =
+    await Promise.all([
+    expenseIds.length > 0
+      ? db.select().from(expenseSplits).where(inArray(expenseSplits.expenseId, expenseIds))
+      : Promise.resolve([] as ExpenseSplitRow[]),
+    expenseIds.length > 0
+      ? db.select().from(expenseRevisions).where(inArray(expenseRevisions.expenseId, expenseIds))
+      : Promise.resolve([] as ExpenseRevisionRow[]),
+    ]);
+
+  const splitsByExpenseId = new Map<string, ExpenseSplitRow[]>();
+  for (const split of groupExpenseSplits) {
+    const existing = splitsByExpenseId.get(split.expenseId);
+    if (existing) {
+      existing.push(split);
+    } else {
+      splitsByExpenseId.set(split.expenseId, [split]);
+    }
+  }
+
+  const expensesWithSplits = groupExpenses.map((expense) => ({
+    ...expense,
+    splits: splitsByExpenseId.get(expense.id) ?? [],
+  }));
 
   const balances = calculateBalances(groupMembers, expensesWithSplits, groupSettlements);
   const debts = simplifyDebts(balances);
   const memberMap = new Map(groupMembers.map((m) => [m.id, m.name]));
+  const showReopenedLedgerWarning =
+    debts.length > 0 &&
+    hasExpenseEditsAfterSettlementStarted(groupExpenseRevisions, groupSettlements);
+  const reversedSettlementIds = new Set(
+    groupSettlements
+      .filter((settlement) => settlement.reversalOfSettlementId)
+      .map((settlement) => settlement.reversalOfSettlementId as string)
+  );
+  const settlementActivity = [...groupSettlements].sort((a, b) =>
+    a.createdAt < b.createdAt ? 1 : a.createdAt > b.createdAt ? -1 : 0
+  );
 
   const settleAction = createSettlement.bind(null, id);
 
@@ -55,6 +93,19 @@ export default async function SettlePage({
         </Link>
         <h1 className="text-2xl font-bold text-slate-900 mt-1">Settle Up</h1>
       </div>
+
+      {showReopenedLedgerWarning && (
+        <div className="bg-amber-50 border border-amber-200 rounded-xl px-4 py-3">
+          <p className="text-sm font-medium text-amber-900">
+            Payments remain in your history, but edited expenses reopened the current
+            ledger.
+          </p>
+          <p className="text-sm text-amber-800 mt-1">
+            Earlier payments stay recorded. If the balances below still show debt, record
+            another payment to settle the current ledger.
+          </p>
+        </div>
+      )}
 
       {/* Suggested payments */}
       <section>
@@ -171,36 +222,52 @@ export default async function SettlePage({
         </form>
       </section>
 
-      {/* History */}
-      {groupSettlements.length > 0 && (
+      {/* Settlement Activity */}
+      {settlementActivity.length > 0 && (
         <section>
-          <h2 className="font-semibold text-slate-900 mb-3">Payment History</h2>
+          <h2 className="font-semibold text-slate-900 mb-1">Settlement Activity</h2>
+          <p className="text-sm text-slate-500 mb-3">
+            Settlement records stay in the ledger. If an older expense changes later, add
+            another payment instead of rewriting history.
+          </p>
           <div className="space-y-2">
-            {[...groupSettlements].reverse().map((s) => (
+            {settlementActivity.map((s) => (
               <div
                 key={s.id}
                 className="bg-white border border-slate-200 rounded-lg px-4 py-3 flex items-start justify-between gap-3"
               >
                 <div>
+                  <p className="text-sm font-medium text-slate-900 mb-1">
+                    {s.reversalOfSettlementId ? "Payment reversed" : "Payment recorded"}
+                  </p>
                   <p className="text-sm">
                     <span className="font-semibold">{memberMap.get(s.paidById)}</span>
                     <span className="text-slate-500"> paid </span>
                     <span className="font-semibold">{memberMap.get(s.paidToId)}</span>
-                    <span className="font-bold text-green-600"> {formatCurrency(s.amount)}</span>
+                    <span
+                      className={`font-bold ${
+                        s.reversalOfSettlementId ? "text-amber-700" : "text-green-600"
+                      }`}
+                    >
+                      {" "}
+                      {formatCurrency(s.amount)}
+                    </span>
                   </p>
                   <p className="text-xs text-slate-400 mt-0.5">
                     {formatDate(s.date)}
                     {s.note ? ` · ${s.note}` : ""}
                   </p>
                 </div>
-                <ConfirmDeleteButton
-                  action={deleteSettlement.bind(null, id, s.id)}
-                  message="Delete this payment record? This cannot be undone."
-                  className="text-slate-300 hover:text-red-400 transition-colors text-lg leading-none"
-                  title="Delete record"
-                >
-                  ×
-                </ConfirmDeleteButton>
+                {!s.reversalOfSettlementId && !reversedSettlementIds.has(s.id) && (
+                  <ConfirmDeleteButton
+                    action={reverseSettlement.bind(null, id, s.id)}
+                    message="Record a reversing payment for this entry?"
+                    className="text-sm text-amber-700 hover:text-amber-800 font-medium transition-colors"
+                    title="Reverse payment"
+                  >
+                    Reverse payment
+                  </ConfirmDeleteButton>
+                )}
               </div>
             ))}
           </div>

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,5 +1,5 @@
 import { sql } from "drizzle-orm";
-import { real, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { foreignKey, real, sqliteTable, text } from "drizzle-orm/sqlite-core";
 
 export const groups = sqliteTable("groups", {
   id: text("id").primaryKey(),
@@ -50,21 +50,43 @@ export const expenseSplits = sqliteTable("expense_splits", {
   amount: real("amount").notNull(),
 });
 
-export const settlements = sqliteTable("settlements", {
+export const expenseRevisions = sqliteTable("expense_revisions", {
   id: text("id").primaryKey(),
-  groupId: text("group_id")
+  expenseId: text("expense_id")
     .notNull()
-    .references(() => groups.id, { onDelete: "cascade" }),
-  paidById: text("paid_by_id")
-    .notNull()
-    .references(() => members.id),
-  paidToId: text("paid_to_id")
-    .notNull()
-    .references(() => members.id),
-  amount: real("amount").notNull(),
-  note: text("note"),
-  date: text("date").notNull(),
+    .references(() => expenses.id, { onDelete: "cascade" }),
+  beforeSnapshot: text("before_snapshot").notNull(),
+  afterSnapshot: text("after_snapshot").notNull(),
   createdAt: text("created_at")
     .notNull()
     .default(sql`(datetime('now'))`),
 });
+
+export const settlements = sqliteTable(
+  "settlements",
+  {
+    id: text("id").primaryKey(),
+    groupId: text("group_id")
+      .notNull()
+      .references(() => groups.id, { onDelete: "cascade" }),
+    paidById: text("paid_by_id")
+      .notNull()
+      .references(() => members.id),
+    paidToId: text("paid_to_id")
+      .notNull()
+      .references(() => members.id),
+    amount: real("amount").notNull(),
+    note: text("note"),
+    reversalOfSettlementId: text("reversal_of_settlement_id"),
+    date: text("date").notNull(),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.reversalOfSettlementId],
+      foreignColumns: [table.id],
+    }),
+  ]
+);

--- a/src/lib/__tests__/balances.test.ts
+++ b/src/lib/__tests__/balances.test.ts
@@ -98,6 +98,31 @@ describe("calculateBalances", () => {
     expect(netOf(balances, "bob")).toBe(2);
   });
 
+  it("editing an already-settled expense can reopen balances while keeping the old settlement", () => {
+    const balances = calculateBalances(
+      [m("alice"), m("bob")],
+      [exp("alice", 20, [["alice", 10], ["bob", 10]])],
+      [settle("bob", "alice", 5)]
+    );
+
+    expect(netOf(balances, "alice")).toBe(5);
+    expect(netOf(balances, "bob")).toBe(-5);
+  });
+
+  it("a reversal settlement cancels the original payment without deleting ledger history", () => {
+    const balances = calculateBalances(
+      [m("alice"), m("bob")],
+      [exp("alice", 10, [["alice", 5], ["bob", 5]])],
+      [
+        settle("bob", "alice", 5),
+        settle("alice", "bob", 5),
+      ]
+    );
+
+    expect(netOf(balances, "alice")).toBe(5);
+    expect(netOf(balances, "bob")).toBe(-5);
+  });
+
   it("all net balances sum to zero (conservation of money)", () => {
     // Money doesn't appear or disappear — every credit has a matching debit.
     const balances = calculateBalances(

--- a/src/lib/__tests__/history.test.ts
+++ b/src/lib/__tests__/history.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildActivityEvents,
+  createExpenseSnapshot,
+  getPostSettlementEditedExpenseIds,
+  hasExpenseEditsAfterSettlementStarted,
+  parseExpenseSnapshot,
+  serializeExpenseSnapshot,
+  type ExpenseSnapshot,
+} from "../history";
+
+describe("expense snapshot serialization", () => {
+  it("builds a snapshot from an expense row and its current split rows", () => {
+    expect(
+      createExpenseSnapshot(
+        {
+          description: "Brunch",
+          amount: 18,
+          paidById: "alice",
+          splitType: "equal",
+          date: "2026-04-26",
+        },
+        [
+          { memberId: "alice", amount: 9 },
+          { memberId: "bob", amount: 9 },
+        ]
+      )
+    ).toEqual({
+      description: "Brunch",
+      amount: 18,
+      paidById: "alice",
+      splitType: "equal",
+      date: "2026-04-26",
+      splits: [
+        { memberId: "alice", amount: 9 },
+        { memberId: "bob", amount: 9 },
+      ],
+    });
+  });
+
+  it("round-trips a full expense snapshot including split details", () => {
+    const snapshot: ExpenseSnapshot = {
+      description: "Dinner",
+      amount: 42.75,
+      paidById: "alice",
+      splitType: "exact",
+      date: "2026-04-25",
+      splits: [
+        { memberId: "alice", amount: 12.75 },
+        { memberId: "bob", amount: 30 },
+      ],
+    };
+
+    const serialized = serializeExpenseSnapshot(snapshot);
+
+    expect(parseExpenseSnapshot(serialized)).toEqual(snapshot);
+  });
+});
+
+describe("buildActivityEvents", () => {
+  it("merges expense, edit, settlement, and reversal events in descending time order", () => {
+    const events = buildActivityEvents({
+      expenses: [
+        {
+          id: "expense-1",
+          description: "Cab",
+          amount: 24,
+          paidById: "alice",
+          splitType: "equal",
+          date: "2026-04-20",
+          createdAt: "2026-04-20 09:00:00",
+        },
+      ],
+      revisions: [
+        {
+          id: "revision-1",
+          expenseId: "expense-1",
+          beforeSnapshot: serializeExpenseSnapshot({
+            description: "Cab",
+            amount: 24,
+            paidById: "alice",
+            splitType: "equal",
+            date: "2026-04-20",
+            splits: [
+              { memberId: "alice", amount: 12 },
+              { memberId: "bob", amount: 12 },
+            ],
+          }),
+          afterSnapshot: serializeExpenseSnapshot({
+            description: "Cab + toll",
+            amount: 30,
+            paidById: "alice",
+            splitType: "equal",
+            date: "2026-04-20",
+            splits: [
+              { memberId: "alice", amount: 15 },
+              { memberId: "bob", amount: 15 },
+            ],
+          }),
+          createdAt: "2026-04-22 12:00:00",
+        },
+      ],
+      settlements: [
+        {
+          id: "settlement-1",
+          paidById: "bob",
+          paidToId: "alice",
+          amount: 12,
+          note: "Venmo",
+          date: "2026-04-21",
+          createdAt: "2026-04-21 08:00:00",
+          reversalOfSettlementId: null,
+        },
+        {
+          id: "settlement-2",
+          paidById: "alice",
+          paidToId: "bob",
+          amount: 12,
+          note: "Reversal of payment from Apr 21, 2026",
+          date: "2026-04-23",
+          createdAt: "2026-04-23 09:30:00",
+          reversalOfSettlementId: "settlement-1",
+        },
+      ],
+    });
+
+    expect(events.map((event) => event.type)).toEqual([
+      "settlement_reversed",
+      "expense_edited",
+      "settlement_recorded",
+      "expense_created",
+    ]);
+    expect(events[0]).toMatchObject({
+      settlementId: "settlement-2",
+      reversalOfSettlementId: "settlement-1",
+    });
+    expect(events[1]).toMatchObject({
+      expenseId: "expense-1",
+      before: { description: "Cab", amount: 24 },
+      after: { description: "Cab + toll", amount: 30 },
+    });
+  });
+});
+
+describe("hasExpenseEditsAfterSettlementStarted", () => {
+  it("returns true when an expense revision was recorded after settlement activity began", () => {
+    expect(
+      hasExpenseEditsAfterSettlementStarted(
+        [
+          {
+            id: "revision-1",
+            expenseId: "expense-1",
+            beforeSnapshot: "{}",
+            afterSnapshot: "{}",
+            createdAt: "2026-04-22 12:00:00",
+          },
+        ],
+        [
+          {
+            id: "settlement-1",
+            paidById: "bob",
+            paidToId: "alice",
+            amount: 5,
+            note: null,
+            date: "2026-04-21",
+            createdAt: "2026-04-21 08:00:00",
+            reversalOfSettlementId: null,
+          },
+        ]
+      )
+    ).toBe(true);
+  });
+
+  it("returns false when revisions all happened before the first settlement", () => {
+    expect(
+      hasExpenseEditsAfterSettlementStarted(
+        [
+          {
+            id: "revision-1",
+            expenseId: "expense-1",
+            beforeSnapshot: "{}",
+            afterSnapshot: "{}",
+            createdAt: "2026-04-20 12:00:00",
+          },
+        ],
+        [
+          {
+            id: "settlement-1",
+            paidById: "bob",
+            paidToId: "alice",
+            amount: 5,
+            note: null,
+            date: "2026-04-21",
+            createdAt: "2026-04-21 08:00:00",
+            reversalOfSettlementId: null,
+          },
+        ]
+      )
+    ).toBe(false);
+  });
+
+  it("treats same-second edits as post-settlement when timestamps share SQLite precision", () => {
+    expect(
+      hasExpenseEditsAfterSettlementStarted(
+        [
+          {
+            id: "revision-1",
+            expenseId: "expense-1",
+            beforeSnapshot: "{}",
+            afterSnapshot: "{}",
+            createdAt: "2026-04-21 08:00:00",
+          },
+        ],
+        [
+          {
+            id: "settlement-1",
+            paidById: "bob",
+            paidToId: "alice",
+            amount: 5,
+            note: null,
+            date: "2026-04-21",
+            createdAt: "2026-04-21 08:00:00",
+            reversalOfSettlementId: null,
+          },
+        ]
+      )
+    ).toBe(true);
+  });
+
+  it("returns the ids of expenses edited after settlement activity began", () => {
+    expect(
+      Array.from(
+        getPostSettlementEditedExpenseIds(
+          [
+            {
+              id: "revision-1",
+              expenseId: "expense-1",
+              beforeSnapshot: "{}",
+              afterSnapshot: "{}",
+              createdAt: "2026-04-22 12:00:00",
+            },
+            {
+              id: "revision-2",
+              expenseId: "expense-2",
+              beforeSnapshot: "{}",
+              afterSnapshot: "{}",
+              createdAt: "2026-04-20 12:00:00",
+            },
+          ],
+          [
+            {
+              id: "settlement-1",
+              paidById: "bob",
+              paidToId: "alice",
+              amount: 5,
+              note: null,
+              date: "2026-04-21",
+              createdAt: "2026-04-21 08:00:00",
+              reversalOfSettlementId: null,
+            },
+          ]
+        )
+      )
+    ).toEqual(["expense-1"]);
+  });
+});

--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -1,0 +1,162 @@
+export type ExpenseSnapshot = {
+  description: string;
+  amount: number;
+  paidById: string;
+  splitType: "equal" | "shares" | "percentage" | "exact";
+  date: string;
+  splits: { memberId: string; amount: number }[];
+};
+
+export type ExpenseRevision = {
+  id: string;
+  expenseId: string;
+  beforeSnapshot: string;
+  afterSnapshot: string;
+  createdAt: string;
+};
+
+export type ActivityExpense = {
+  id: string;
+  description: string;
+  amount: number;
+  paidById: string;
+  splitType: ExpenseSnapshot["splitType"];
+  date: string;
+  createdAt: string;
+};
+
+export type ActivitySettlement = {
+  id: string;
+  paidById: string;
+  paidToId: string;
+  amount: number;
+  note: string | null;
+  date: string;
+  createdAt: string;
+  reversalOfSettlementId: string | null;
+};
+
+export type ActivityEvent =
+  | {
+      id: string;
+      type: "expense_created";
+      occurredAt: string;
+      expenseId: string;
+      expense: ActivityExpense;
+    }
+  | {
+      id: string;
+      type: "expense_edited";
+      occurredAt: string;
+      expenseId: string;
+      revisionId: string;
+      before: ExpenseSnapshot;
+      after: ExpenseSnapshot;
+    }
+  | {
+      id: string;
+      type: "settlement_recorded" | "settlement_reversed";
+      occurredAt: string;
+      settlementId: string;
+      paidById: string;
+      paidToId: string;
+      amount: number;
+      note: string | null;
+      date: string;
+      reversalOfSettlementId: string | null;
+    };
+
+export function serializeExpenseSnapshot(snapshot: ExpenseSnapshot): string {
+  return JSON.stringify(snapshot);
+}
+
+export function parseExpenseSnapshot(serialized: string): ExpenseSnapshot {
+  return JSON.parse(serialized) as ExpenseSnapshot;
+}
+
+export function createExpenseSnapshot(
+  expense: Omit<ExpenseSnapshot, "splits">,
+  splits: ExpenseSnapshot["splits"]
+): ExpenseSnapshot {
+  return {
+    ...expense,
+    splits: splits.map((split) => ({ ...split })),
+  };
+}
+
+export function buildActivityEvents({
+  expenses,
+  revisions,
+  settlements,
+}: {
+  expenses: ActivityExpense[];
+  revisions: ExpenseRevision[];
+  settlements: ActivitySettlement[];
+}): ActivityEvent[] {
+  const events: ActivityEvent[] = [
+    ...expenses.map((expense) => ({
+      id: `expense-created-${expense.id}`,
+      type: "expense_created" as const,
+      occurredAt: expense.createdAt,
+      expenseId: expense.id,
+      expense,
+    })),
+    ...revisions.map((revision) => ({
+      id: `expense-edited-${revision.id}`,
+      type: "expense_edited" as const,
+      occurredAt: revision.createdAt,
+      expenseId: revision.expenseId,
+      revisionId: revision.id,
+      before: parseExpenseSnapshot(revision.beforeSnapshot),
+      after: parseExpenseSnapshot(revision.afterSnapshot),
+    })),
+    ...settlements.map((settlement) => {
+      const type: "settlement_recorded" | "settlement_reversed" =
+        settlement.reversalOfSettlementId ? "settlement_reversed" : "settlement_recorded";
+
+      return {
+        id: `settlement-${settlement.id}`,
+        type,
+        occurredAt: settlement.createdAt,
+        settlementId: settlement.id,
+        paidById: settlement.paidById,
+        paidToId: settlement.paidToId,
+        amount: settlement.amount,
+        note: settlement.note,
+        date: settlement.date,
+        reversalOfSettlementId: settlement.reversalOfSettlementId,
+      };
+    }),
+  ];
+
+  return events.sort((a, b) => toTimestampMs(b.occurredAt) - toTimestampMs(a.occurredAt));
+}
+
+export function hasExpenseEditsAfterSettlementStarted(
+  revisions: Pick<ExpenseRevision, "createdAt">[],
+  settlements: Pick<ActivitySettlement, "createdAt">[]
+): boolean {
+  if (revisions.length === 0 || settlements.length === 0) return false;
+
+  const firstSettlementAt = Math.min(...settlements.map((settlement) => toTimestampMs(settlement.createdAt)));
+  return revisions.some((revision) => toTimestampMs(revision.createdAt) >= firstSettlementAt);
+}
+
+export function getPostSettlementEditedExpenseIds(
+  revisions: Pick<ExpenseRevision, "expenseId" | "createdAt">[],
+  settlements: Pick<ActivitySettlement, "createdAt">[]
+): Set<string> {
+  if (revisions.length === 0 || settlements.length === 0) return new Set();
+
+  const firstSettlementAt = Math.min(...settlements.map((settlement) => toTimestampMs(settlement.createdAt)));
+  return new Set(
+    revisions
+      .filter((revision) => toTimestampMs(revision.createdAt) >= firstSettlementAt)
+      .map((revision) => revision.expenseId)
+  );
+}
+
+function toTimestampMs(value: string): number {
+  const normalized = value.includes("T") ? value : value.replace(" ", "T");
+  return new Date(normalized).getTime();
+}


### PR DESCRIPTION
## What changed
Adds a ledger-first settle-up history flow.

- records immutable expense revisions with before/after snapshots
- replaces settlement deletion with append-only reversal entries
- adds group activity history plus edited/reopened badges and settle-up warnings
- extends unit and e2e coverage for reopened balances, activity history, and payment reversal

## Why
Settlements should remain historical facts even when older expenses are edited later. This keeps the ledger trustworthy while making reopened balances visible to the user.

## User impact
Users can now see when an edited expense changed balances after payments were already recorded, and they can reverse a payment without erasing history.

## Validation
- `npm test`
- `npm run test:e2e`
- `npm run build`
