### PR TITLE
[codex] Prevent duplicate submits across write flows

### DIFF
--- a/drizzle/0003_abandoned_black_bolt.sql
+++ b/drizzle/0003_abandoned_black_bolt.sql
@@ -1,0 +1,11 @@
+CREATE TABLE `idempotent_submissions` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`action_kind` text NOT NULL,
+	`submission_token` text NOT NULL,
+	`redirect_path` text NOT NULL,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `idempotent_submissions_user_action_token_unique` ON `idempotent_submissions` (`user_id`,`action_kind`,`submission_token`);

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,683 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "f11edcbe-47d8-4b19-809f-0533ce6eb749",
+  "prevId": "e6703dba-2fa9-4905-bf46-6ae1039790f3",
+  "tables": {
+    "expense_revisions": {
+      "name": "expense_revisions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expense_id": {
+          "name": "expense_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "before_snapshot": {
+          "name": "before_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "after_snapshot": {
+          "name": "after_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "expense_revisions_expense_id_expenses_id_fk": {
+          "name": "expense_revisions_expense_id_expenses_id_fk",
+          "tableFrom": "expense_revisions",
+          "tableTo": "expenses",
+          "columnsFrom": [
+            "expense_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "expense_splits": {
+      "name": "expense_splits",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expense_id": {
+          "name": "expense_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "expense_splits_expense_id_expenses_id_fk": {
+          "name": "expense_splits_expense_id_expenses_id_fk",
+          "tableFrom": "expense_splits",
+          "tableTo": "expenses",
+          "columnsFrom": [
+            "expense_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "expense_splits_member_id_members_id_fk": {
+          "name": "expense_splits_member_id_members_id_fk",
+          "tableFrom": "expense_splits",
+          "tableTo": "members",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "expenses": {
+      "name": "expenses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "paid_by_id": {
+          "name": "paid_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "split_type": {
+          "name": "split_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "expenses_group_id_groups_id_fk": {
+          "name": "expenses_group_id_groups_id_fk",
+          "tableFrom": "expenses",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "expenses_paid_by_id_members_id_fk": {
+          "name": "expenses_paid_by_id_members_id_fk",
+          "tableFrom": "expenses",
+          "tableTo": "members",
+          "columnsFrom": [
+            "paid_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "group_access": {
+      "name": "group_access",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "group_access_group_user_unique": {
+          "name": "group_access_group_user_unique",
+          "columns": [
+            "group_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "group_access_group_id_groups_id_fk": {
+          "name": "group_access_group_id_groups_id_fk",
+          "tableFrom": "group_access",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_access_user_id_users_id_fk": {
+          "name": "group_access_user_id_users_id_fk",
+          "tableFrom": "group_access",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "groups": {
+      "name": "groups",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "groups_created_by_user_id_users_id_fk": {
+          "name": "groups_created_by_user_id_users_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "idempotent_submissions": {
+      "name": "idempotent_submissions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_kind": {
+          "name": "action_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "submission_token": {
+          "name": "submission_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "redirect_path": {
+          "name": "redirect_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idempotent_submissions_user_action_token_unique": {
+          "name": "idempotent_submissions_user_action_token_unique",
+          "columns": [
+            "user_id",
+            "action_kind",
+            "submission_token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "idempotent_submissions_user_id_users_id_fk": {
+          "name": "idempotent_submissions_user_id_users_id_fk",
+          "tableFrom": "idempotent_submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "members": {
+      "name": "members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "members_group_id_groups_id_fk": {
+          "name": "members_group_id_groups_id_fk",
+          "tableFrom": "members",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settlements": {
+      "name": "settlements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "paid_by_id": {
+          "name": "paid_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "paid_to_id": {
+          "name": "paid_to_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reversal_of_settlement_id": {
+          "name": "reversal_of_settlement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "settlements_group_id_groups_id_fk": {
+          "name": "settlements_group_id_groups_id_fk",
+          "tableFrom": "settlements",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "settlements_paid_by_id_members_id_fk": {
+          "name": "settlements_paid_by_id_members_id_fk",
+          "tableFrom": "settlements",
+          "tableTo": "members",
+          "columnsFrom": [
+            "paid_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "settlements_paid_to_id_members_id_fk": {
+          "name": "settlements_paid_to_id_members_id_fk",
+          "tableFrom": "settlements",
+          "tableTo": "members",
+          "columnsFrom": [
+            "paid_to_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "settlements_reversal_of_settlement_id_settlements_id_fk": {
+          "name": "settlements_reversal_of_settlement_id_settlements_id_fk",
+          "tableFrom": "settlements",
+          "tableTo": "settlements",
+          "columnsFrom": [
+            "reversal_of_settlement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1777223992721,
       "tag": "0002_overrated_pestilence",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1777261198039,
+      "tag": "0003_abandoned_black_bolt",
+      "breakpoints": true
     }
   ]
 }

--- a/e2e/expenses.spec.ts
+++ b/e2e/expenses.spec.ts
@@ -35,6 +35,27 @@ test.describe("Adding expenses – equal split", () => {
     ).toHaveCount(1);
   });
 
+  test("legitimate second expense create after revisiting the form is not replayed", async ({
+    page,
+  }) => {
+    const id = await createTestGroup(page, "Fresh Tokens", ["Alice", "Bob"]);
+
+    await fillExpenseBase(page, id, { description: "Dinner", amount: "10", paidBy: "Alice" });
+    await page.getByRole("button", { name: "Add Expense" }).click();
+    await expect(page).toHaveURL(`/groups/${id}`);
+
+    await fillExpenseBase(page, id, { description: "Lunch", amount: "12", paidBy: "Bob" });
+    await page.getByRole("button", { name: "Add Expense" }).click();
+    await expect(page).toHaveURL(`/groups/${id}`);
+
+    const expensesSection = page
+      .locator("section")
+      .filter({ has: page.getByRole("heading", { name: "Expenses" }) });
+
+    await expect(expensesSection.getByText("Dinner", { exact: true })).toHaveCount(1);
+    await expect(expensesSection.getByText("Lunch", { exact: true })).toHaveCount(1);
+  });
+
   test("payer gets the higher cent when $10 splits 3 ways ($3.34 not $3.33)", async ({ page }) => {
     // Rounding rule: Alice paid → Alice owes $3.34, others $3.33 each.
     const id = await createTestGroup(page, "E2E Equal 3", ["Alice", "Bob", "Carol"]);

--- a/e2e/expenses.spec.ts
+++ b/e2e/expenses.spec.ts
@@ -19,6 +19,22 @@ test.describe("Adding expenses – equal split", () => {
     await expect(page.getByText("-$5.00")).toBeVisible();
   });
 
+  test("double-clicking Add Expense only creates one expense", async ({ page }) => {
+    const id = await createTestGroup(page, "No Duplicates", ["Alice", "Bob"]);
+    await fillExpenseBase(page, id, { description: "Dinner", amount: "10", paidBy: "Alice" });
+
+    const submit = page.getByRole("button", { name: "Add Expense" });
+    await submit.dblclick();
+
+    await expect(page).toHaveURL(`/groups/${id}`);
+    await expect(
+      page
+        .locator("section")
+        .filter({ has: page.getByRole("heading", { name: "Expenses" }) })
+        .getByText("Dinner", { exact: true })
+    ).toHaveCount(1);
+  });
+
   test("payer gets the higher cent when $10 splits 3 ways ($3.34 not $3.33)", async ({ page }) => {
     // Rounding rule: Alice paid → Alice owes $3.34, others $3.33 each.
     const id = await createTestGroup(page, "E2E Equal 3", ["Alice", "Bob", "Carol"]);

--- a/e2e/expenses.spec.ts
+++ b/e2e/expenses.spec.ts
@@ -56,6 +56,37 @@ test.describe("Adding expenses – equal split", () => {
     await expect(expensesSection.getByText("Lunch", { exact: true })).toHaveCount(1);
   });
 
+  test("legitimate expense create from a restored form gets a fresh token", async ({
+    page,
+  }) => {
+    const id = await createTestGroup(page, "Back Expenses", ["Alice", "Bob"]);
+
+    await fillExpenseBase(page, id, { description: "Dinner", amount: "10", paidBy: "Alice" });
+    const firstToken = await page.locator('input[name="_submissionToken"]').inputValue();
+
+    await page.goto(`/groups/${id}`);
+    await expect(page).toHaveURL(`/groups/${id}`);
+
+    await page.goBack();
+    await expect(page).toHaveURL(`/groups/${id}/expenses/new`);
+    await page.waitForFunction((token) => {
+      const input = document.querySelector<HTMLInputElement>('input[name="_submissionToken"]');
+      return input ? input.value !== token : false;
+    }, firstToken);
+
+    await page.getByPlaceholder("e.g. Dinner, Hotel, Uber").fill("Dinner");
+    await page.getByPlaceholder("0.00").fill("10");
+    await page.getByRole("combobox", { name: /Paid by/i }).selectOption({ label: "Alice" });
+    await page.getByRole("button", { name: "Add Expense" }).click();
+    await expect(page).toHaveURL(`/groups/${id}`);
+
+    const expensesSection = page
+      .locator("section")
+      .filter({ has: page.getByRole("heading", { name: "Expenses" }) });
+
+    await expect(expensesSection.getByText("Dinner", { exact: true })).toHaveCount(1);
+  });
+
   test("payer gets the higher cent when $10 splits 3 ways ($3.34 not $3.33)", async ({ page }) => {
     // Rounding rule: Alice paid → Alice owes $3.34, others $3.33 each.
     const id = await createTestGroup(page, "E2E Equal 3", ["Alice", "Bob", "Carol"]);

--- a/e2e/groups.spec.ts
+++ b/e2e/groups.spec.ts
@@ -61,6 +61,37 @@ test.describe("Group management", () => {
     await expect(page.locator("a").filter({ hasText: "Second Cabin" })).toHaveCount(1);
   });
 
+  test("legitimate group create from a restored form gets a fresh token", async ({
+    page,
+  }) => {
+    await signUpAndLogin(page);
+
+    await page.goto("/groups/new");
+    const firstToken = await page.locator('input[name="_submissionToken"]').inputValue();
+    await page.getByPlaceholder("e.g. Tokyo Trip, Apartment").fill("Back Cabin");
+    await page.getByPlaceholder("Member 1").fill("Alice");
+    await page.getByPlaceholder("Member 2").fill("Bob");
+
+    await page.goto("/");
+    await expect(page).toHaveURL("/");
+
+    await page.goBack();
+    await expect(page).toHaveURL("/groups/new");
+    await page.waitForFunction((token) => {
+      const input = document.querySelector<HTMLInputElement>('input[name="_submissionToken"]');
+      return input ? input.value !== token : false;
+    }, firstToken);
+
+    await page.getByPlaceholder("e.g. Tokyo Trip, Apartment").fill("Back Cabin");
+    await page.getByPlaceholder("Member 1").fill("Alice");
+    await page.getByPlaceholder("Member 2").fill("Bob");
+    await page.getByRole("button", { name: "Create Group" }).click();
+    await expect(page).toHaveURL(/\/groups\/[^/]+$/);
+
+    await page.goto("/");
+    await expect(page.locator("a").filter({ hasText: "Back Cabin" })).toHaveCount(1);
+  });
+
   test("new group appears on the home page", async ({ page }) => {
     const id = await createTestGroup(page, "Barcelona Trip", ["Maria", "Carlos"]);
 

--- a/e2e/groups.spec.ts
+++ b/e2e/groups.spec.ts
@@ -177,6 +177,51 @@ test.describe("Group management", () => {
     ).toHaveCount(1);
   });
 
+  test("Add member shows a pending state while submission is in flight", async ({ page }) => {
+    const id = await createTestGroup(page, "Dinner Club Pending Add", ["Alice", "Bob"]);
+
+    await page.getByPlaceholder("Add a member…").fill("Carol");
+
+    let releaseSubmit: () => void;
+    const submitBlocked = new Promise<void>((resolve) => {
+      releaseSubmit = resolve;
+    });
+    let sawSubmitRequest = false;
+
+    await page.route("**/*", async (route) => {
+      const request = route.request();
+
+      if (
+        !sawSubmitRequest &&
+        request.method() === "POST" &&
+        new URL(request.url()).pathname === `/groups/${id}`
+      ) {
+        sawSubmitRequest = true;
+        await submitBlocked;
+      }
+
+      await route.continue();
+    });
+
+    const membersSection = page
+      .locator("section")
+      .filter({ has: page.getByRole("heading", { name: "Members" }) });
+    const submit = membersSection.locator('button[type="submit"]');
+    const clickPromise = submit.click();
+
+    await expect.poll(() => sawSubmitRequest).toBe(true);
+    await expect(submit).toBeDisabled();
+    await expect(submit).toHaveText("Adding...");
+
+    releaseSubmit!();
+    await clickPromise;
+
+    await expect(page.getByText("3 members")).toBeVisible();
+    await expect(
+      membersSection.getByText("Carol", { exact: true })
+    ).toBeVisible();
+  });
+
   test("can navigate back to home from a group page", async ({ page }) => {
     await createTestGroup(page, "Road Trip", ["Alice", "Bob"]);
 

--- a/e2e/groups.spec.ts
+++ b/e2e/groups.spec.ts
@@ -117,6 +117,21 @@ test.describe("Group management", () => {
     ).toBeVisible();
   });
 
+  test("double-clicking Add only adds one member", async ({ page }) => {
+    await createTestGroup(page, "Dinner Club Double Add", ["Alice", "Bob"]);
+
+    await page.getByPlaceholder("Add a member…").fill("Carol");
+    await page.getByRole("button", { name: "Add" }).dblclick();
+
+    await expect(page.getByText("3 members")).toBeVisible();
+    await expect(
+      page
+        .locator("section")
+        .filter({ has: page.getByRole("heading", { name: "Members" }) })
+        .getByText("Carol", { exact: true })
+    ).toHaveCount(1);
+  });
+
   test("can navigate back to home from a group page", async ({ page }) => {
     await createTestGroup(page, "Road Trip", ["Alice", "Bob"]);
 

--- a/e2e/groups.spec.ts
+++ b/e2e/groups.spec.ts
@@ -37,6 +37,30 @@ test.describe("Group management", () => {
     await expect(page.locator("a").filter({ hasText: "One Cabin" })).toHaveCount(1);
   });
 
+  test("legitimate second group create after revisiting the form is not replayed", async ({
+    page,
+  }) => {
+    await signUpAndLogin(page);
+
+    await page.goto("/groups/new");
+    await page.getByPlaceholder("e.g. Tokyo Trip, Apartment").fill("First Cabin");
+    await page.getByPlaceholder("Member 1").fill("Alice");
+    await page.getByPlaceholder("Member 2").fill("Bob");
+    await page.getByRole("button", { name: "Create Group" }).click();
+    await expect(page).toHaveURL(/\/groups\/[^/]+$/);
+
+    await page.goto("/groups/new");
+    await page.getByPlaceholder("e.g. Tokyo Trip, Apartment").fill("Second Cabin");
+    await page.getByPlaceholder("Member 1").fill("Alice");
+    await page.getByPlaceholder("Member 2").fill("Bob");
+    await page.getByRole("button", { name: "Create Group" }).click();
+    await expect(page).toHaveURL(/\/groups\/[^/]+$/);
+
+    await page.goto("/");
+    await expect(page.locator("a").filter({ hasText: "First Cabin" })).toHaveCount(1);
+    await expect(page.locator("a").filter({ hasText: "Second Cabin" })).toHaveCount(1);
+  });
+
   test("new group appears on the home page", async ({ page }) => {
     const id = await createTestGroup(page, "Barcelona Trip", ["Maria", "Carlos"]);
 

--- a/e2e/groups.spec.ts
+++ b/e2e/groups.spec.ts
@@ -37,6 +37,51 @@ test.describe("Group management", () => {
     await expect(page.locator("a").filter({ hasText: "One Cabin" })).toHaveCount(1);
   });
 
+  test("Create Group shows a pending state while submission is in flight", async ({ page }) => {
+    await signUpAndLogin(page);
+    await page.goto("/groups/new");
+    await page.getByPlaceholder("e.g. Tokyo Trip, Apartment").fill("Pending Cabin");
+    await page.getByPlaceholder("Member 1").fill("Alice");
+    await page.getByPlaceholder("Member 2").fill("Bob");
+
+    let releaseSubmit: () => void;
+    const submitBlocked = new Promise<void>((resolve) => {
+      releaseSubmit = resolve;
+    });
+    let sawSubmitRequest = false;
+
+    await page.route("**/*", async (route) => {
+      const request = route.request();
+
+      if (
+        !sawSubmitRequest &&
+        request.method() === "POST" &&
+        new URL(request.url()).pathname === "/groups/new"
+      ) {
+        sawSubmitRequest = true;
+        await submitBlocked;
+      }
+
+      await route.continue();
+    });
+
+    const form = page.locator("form").filter({
+      has: page.getByPlaceholder("e.g. Tokyo Trip, Apartment"),
+    });
+    const submit = form.locator('button[type="submit"]');
+    const clickPromise = submit.click();
+
+    await expect.poll(() => sawSubmitRequest).toBe(true);
+    await expect(submit).toBeDisabled();
+    await expect(submit).toHaveText("Creating...");
+
+    releaseSubmit!();
+    await clickPromise;
+
+    await expect(page).toHaveURL(/\/groups\/[^/]+$/);
+    await expect(page.getByRole("heading", { name: "Pending Cabin" })).toBeVisible();
+  });
+
   test("legitimate second group create after revisiting the form is not replayed", async ({
     page,
   }) => {

--- a/e2e/groups.spec.ts
+++ b/e2e/groups.spec.ts
@@ -20,6 +20,23 @@ test.describe("Group management", () => {
     await expect(page.getByText("2 members")).toBeVisible();
   });
 
+  test("double-clicking Create Group only creates one group", async ({ page }) => {
+    await signUpAndLogin(page);
+    await page.goto("/groups/new");
+    await page.getByPlaceholder("e.g. Tokyo Trip, Apartment").fill("One Cabin");
+    await page.getByPlaceholder("Member 1").fill("Alice");
+    await page.getByPlaceholder("Member 2").fill("Bob");
+
+    const submit = page.getByRole("button", { name: "Create Group" });
+    await submit.dblclick();
+
+    await expect(page).toHaveURL(/\/groups\/[^/]+$/);
+    await expect(page.getByRole("heading", { name: "One Cabin" })).toBeVisible();
+
+    await page.goto("/");
+    await expect(page.locator("a").filter({ hasText: "One Cabin" })).toHaveCount(1);
+  });
+
   test("new group appears on the home page", async ({ page }) => {
     const id = await createTestGroup(page, "Barcelona Trip", ["Maria", "Carlos"]);
 

--- a/e2e/settle.spec.ts
+++ b/e2e/settle.spec.ts
@@ -108,6 +108,55 @@ test.describe("Settle up", () => {
     await expect(page.getByText("Payment recorded")).toHaveCount(1);
   });
 
+  test("Record Payment shows a pending state while submission is in flight", async ({ page }) => {
+    const id = await createTestGroup(page, "E2E Pending Payment", ["Alice", "Bob"]);
+    await fillExpenseBase(page, id, { description: "Lunch", amount: "30", paidBy: "Alice" });
+    await page.getByRole("button", { name: "Add Expense" }).click();
+
+    await page.goto(`/groups/${id}/settle`);
+    await page.locator("select[name='paidById']").last().selectOption({ label: "Bob" });
+    await page.locator("select[name='paidToId']").last().selectOption({ label: "Alice" });
+    await page.locator("input[name='amount']").last().fill("15");
+    await page.locator("input[name='note']").fill("Pending Venmo");
+
+    let releaseSubmit: () => void;
+    const submitBlocked = new Promise<void>((resolve) => {
+      releaseSubmit = resolve;
+    });
+    let sawSubmitRequest = false;
+
+    await page.route("**/*", async (route) => {
+      const request = route.request();
+
+      if (
+        !sawSubmitRequest &&
+        request.method() === "POST" &&
+        new URL(request.url()).pathname === `/groups/${id}/settle`
+      ) {
+        sawSubmitRequest = true;
+        await submitBlocked;
+      }
+
+      await route.continue();
+    });
+
+    const manualPaymentSection = page
+      .locator("section")
+      .filter({ has: page.getByRole("heading", { name: "Record a Payment" }) });
+    const submit = manualPaymentSection.locator('button[type="submit"]');
+    const clickPromise = submit.click();
+
+    await expect.poll(() => sawSubmitRequest).toBe(true);
+    await expect(submit).toBeDisabled();
+    await expect(submit).toHaveText("Recording...");
+
+    releaseSubmit!();
+    await clickPromise;
+
+    await expect(page.getByText("Pending Venmo")).toBeVisible();
+    await expect(page.getByText("$15.00")).toBeVisible();
+  });
+
   test("editing a settled expense reopens balances and shows a warning on settle up", async ({ page }) => {
     const id = await createTestGroup(page, "E2E Reopen Debt", ["Alice", "Bob"]);
     await fillExpenseBase(page, id, { description: "Museum", amount: "10", paidBy: "Alice" });

--- a/e2e/settle.spec.ts
+++ b/e2e/settle.spec.ts
@@ -90,6 +90,24 @@ test.describe("Settle up", () => {
     await expect(page.getByText("$15.00")).toBeVisible();
   });
 
+  test("double-clicking Record Payment only records one payment", async ({ page }) => {
+    const id = await createTestGroup(page, "E2E History Double Submit", ["Alice", "Bob"]);
+    await fillExpenseBase(page, id, { description: "Lunch", amount: "30", paidBy: "Alice" });
+    await page.getByRole("button", { name: "Add Expense" }).click();
+
+    await page.goto(`/groups/${id}/settle`);
+
+    await page.locator("select[name='paidById']").last().selectOption({ label: "Bob" });
+    await page.locator("select[name='paidToId']").last().selectOption({ label: "Alice" });
+    await page.locator("input[name='amount']").last().fill("15");
+    await page.locator("input[name='note']").fill("Venmo");
+    await page.getByRole("button", { name: "Record Payment" }).dblclick();
+
+    await expect(page.getByText("Venmo")).toHaveCount(1);
+    await expect(page.getByText("$15.00")).toHaveCount(1);
+    await expect(page.getByText("Payment recorded")).toHaveCount(1);
+  });
+
   test("editing a settled expense reopens balances and shows a warning on settle up", async ({ page }) => {
     const id = await createTestGroup(page, "E2E Reopen Debt", ["Alice", "Bob"]);
     await fillExpenseBase(page, id, { description: "Museum", amount: "10", paidBy: "Alice" });

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -11,14 +11,75 @@ import {
   expenses,
   groupAccess,
   groups,
+  idempotentSubmissions,
   members,
   settlements,
 } from "@/db/schema";
 import { requireGroupAccess, requireUser } from "@/lib/server/session";
 import { formatDate, today } from "@/lib/format";
 import { createExpenseSnapshot, serializeExpenseSnapshot } from "@/lib/history";
+import {
+  buildCreateRedirectPath,
+  readSubmissionToken,
+  type CreateActionKind,
+} from "@/lib/idempotency";
 import { computeSplits, type SplitInputs, type SplitType } from "@/lib/splits";
 import { generateId } from "@/lib/utils";
+
+async function findIdempotentSubmission(
+  userId: string,
+  actionKind: CreateActionKind,
+  submissionToken: string
+) {
+  const [submission] = await db
+    .select({
+      redirectPath: idempotentSubmissions.redirectPath,
+    })
+    .from(idempotentSubmissions)
+    .where(
+      and(
+        eq(idempotentSubmissions.userId, userId),
+        eq(idempotentSubmissions.actionKind, actionKind),
+        eq(idempotentSubmissions.submissionToken, submissionToken)
+      )
+    )
+    .limit(1);
+
+  return submission ?? null;
+}
+
+function isUniqueConstraintError(error: unknown) {
+  return error instanceof Error && /unique|constraint/i.test(error.message);
+}
+
+function finishCreateAction(actionKind: CreateActionKind, redirectPath: string) {
+  switch (actionKind) {
+    case "createGroup":
+      redirect(redirectPath);
+    case "createExpense":
+    case "createSettlement":
+      revalidatePath(redirectPath);
+      redirect(redirectPath);
+    case "addMember":
+      revalidatePath(redirectPath);
+      return;
+  }
+}
+
+async function replayExistingCreateAction(
+  userId: string,
+  actionKind: CreateActionKind,
+  submissionToken: string
+) {
+  const existingSubmission = await findIdempotentSubmission(userId, actionKind, submissionToken);
+
+  if (!existingSubmission) {
+    return false;
+  }
+
+  finishCreateAction(actionKind, existingSubmission.redirectPath);
+  return true;
+}
 
 // ─── Groups ──────────────────────────────────────────────────────────────────
 
@@ -28,22 +89,54 @@ export async function createGroup(formData: FormData) {
   const memberNames = (formData.getAll("members") as string[])
     .map((n) => n.trim())
     .filter(Boolean);
+  const actionKind = "createGroup" as const;
+  const submissionToken = readSubmissionToken(formData);
 
   if (!name || memberNames.length < 2) return;
 
-  const groupId = generateId();
-  await db.insert(groups).values({ id: groupId, name, createdByUserId: user.id });
-  await db.insert(groupAccess).values({
-    id: generateId(),
-    groupId,
-    userId: user.id,
-    role: "owner",
-  });
-  await db.insert(members).values(
-    memberNames.map((n) => ({ id: generateId(), groupId, name: n }))
-  );
+  if (submissionToken && (await replayExistingCreateAction(user.id, actionKind, submissionToken))) {
+    return;
+  }
 
-  redirect(`/groups/${groupId}`);
+  const groupId = generateId();
+  const redirectPath = buildCreateRedirectPath(actionKind, { groupId });
+
+  try {
+    await db.transaction(async (tx) => {
+      await tx.insert(groups).values({ id: groupId, name, createdByUserId: user.id });
+      await tx.insert(groupAccess).values({
+        id: generateId(),
+        groupId,
+        userId: user.id,
+        role: "owner",
+      });
+      await tx.insert(members).values(
+        memberNames.map((memberName) => ({ id: generateId(), groupId, name: memberName }))
+      );
+
+      if (submissionToken) {
+        await tx.insert(idempotentSubmissions).values({
+          id: generateId(),
+          userId: user.id,
+          actionKind,
+          submissionToken,
+          redirectPath,
+        });
+      }
+    });
+  } catch (error) {
+    if (
+      submissionToken &&
+      isUniqueConstraintError(error) &&
+      (await replayExistingCreateAction(user.id, actionKind, submissionToken))
+    ) {
+      return;
+    }
+
+    throw error;
+  }
+
+  finishCreateAction(actionKind, redirectPath);
 }
 
 export async function deleteGroup(groupId: string) {
@@ -56,24 +149,59 @@ export async function deleteGroup(groupId: string) {
 // ─── Members ─────────────────────────────────────────────────────────────────
 
 export async function addMember(groupId: string, formData: FormData) {
-  await requireGroupAccess(groupId);
+  const { user } = await requireGroupAccess(groupId);
   const name = (formData.get("name") as string).trim();
+  const actionKind = "addMember" as const;
+  const submissionToken = readSubmissionToken(formData);
   if (!name) return;
 
-  await db.insert(members).values({ id: generateId(), groupId, name });
-  revalidatePath(`/groups/${groupId}`);
+  if (submissionToken && (await replayExistingCreateAction(user.id, actionKind, submissionToken))) {
+    return;
+  }
+
+  const redirectPath = buildCreateRedirectPath(actionKind, { groupId });
+
+  try {
+    await db.transaction(async (tx) => {
+      await tx.insert(members).values({ id: generateId(), groupId, name });
+
+      if (submissionToken) {
+        await tx.insert(idempotentSubmissions).values({
+          id: generateId(),
+          userId: user.id,
+          actionKind,
+          submissionToken,
+          redirectPath,
+        });
+      }
+    });
+  } catch (error) {
+    if (
+      submissionToken &&
+      isUniqueConstraintError(error) &&
+      (await replayExistingCreateAction(user.id, actionKind, submissionToken))
+    ) {
+      return;
+    }
+
+    throw error;
+  }
+
+  finishCreateAction(actionKind, redirectPath);
 }
 
 // ─── Expenses ────────────────────────────────────────────────────────────────
 
 export async function createExpense(groupId: string, formData: FormData) {
-  await requireGroupAccess(groupId);
+  const { user } = await requireGroupAccess(groupId);
   const description = (formData.get("description") as string).trim();
   const amount = parseFloat(formData.get("amount") as string);
   const paidById = formData.get("paidById") as string;
   const splitType = formData.get("splitType") as SplitType;
   const date = formData.get("date") as string;
   const participantIds = formData.getAll("participants") as string[];
+  const actionKind = "createExpense" as const;
+  const submissionToken = readSubmissionToken(formData);
 
   if (
     !description ||
@@ -103,22 +231,52 @@ export async function createExpense(groupId: string, formData: FormData) {
   if (splits.length === 0) return;
 
   const expenseId = generateId();
-  await db.insert(expenses).values({
-    id: expenseId,
-    groupId,
-    description,
-    amount: Math.round(amount * 100) / 100,
-    paidById,
-    splitType,
-    date,
-  });
+  const roundedAmount = Math.round(amount * 100) / 100;
+  const redirectPath = buildCreateRedirectPath(actionKind, { groupId });
 
-  await db.insert(expenseSplits).values(
-    splits.map((s) => ({ id: generateId(), expenseId, ...s }))
-  );
+  if (submissionToken && (await replayExistingCreateAction(user.id, actionKind, submissionToken))) {
+    return;
+  }
 
-  revalidatePath(`/groups/${groupId}`);
-  redirect(`/groups/${groupId}`);
+  try {
+    await db.transaction(async (tx) => {
+      await tx.insert(expenses).values({
+        id: expenseId,
+        groupId,
+        description,
+        amount: roundedAmount,
+        paidById,
+        splitType,
+        date,
+      });
+
+      await tx.insert(expenseSplits).values(
+        splits.map((split) => ({ id: generateId(), expenseId, ...split }))
+      );
+
+      if (submissionToken) {
+        await tx.insert(idempotentSubmissions).values({
+          id: generateId(),
+          userId: user.id,
+          actionKind,
+          submissionToken,
+          redirectPath,
+        });
+      }
+    });
+  } catch (error) {
+    if (
+      submissionToken &&
+      isUniqueConstraintError(error) &&
+      (await replayExistingCreateAction(user.id, actionKind, submissionToken))
+    ) {
+      return;
+    }
+
+    throw error;
+  }
+
+  finishCreateAction(actionKind, redirectPath);
 }
 
 export async function updateExpense(groupId: string, expenseId: string, formData: FormData) {
@@ -218,29 +376,60 @@ export async function deleteExpense(groupId: string, expenseId: string) {
 // ─── Settlements ─────────────────────────────────────────────────────────────
 
 export async function createSettlement(groupId: string, formData: FormData) {
-  await requireGroupAccess(groupId);
+  const { user } = await requireGroupAccess(groupId);
   const paidById = formData.get("paidById") as string;
   const paidToId = formData.get("paidToId") as string;
   const amount = parseFloat(formData.get("amount") as string);
   const note = (formData.get("note") as string)?.trim() || null;
   const date = formData.get("date") as string;
+  const actionKind = "createSettlement" as const;
+  const submissionToken = readSubmissionToken(formData);
 
   if (!paidById || !paidToId || paidById === paidToId || isNaN(amount) || amount <= 0 || !date)
     return;
 
-  await db.insert(settlements).values({
-    id: generateId(),
-    groupId,
-    paidById,
-    paidToId,
-    amount: Math.round(amount * 100) / 100,
-    note,
-    reversalOfSettlementId: null,
-    date,
-  });
+  if (submissionToken && (await replayExistingCreateAction(user.id, actionKind, submissionToken))) {
+    return;
+  }
 
-  revalidatePath(`/groups/${groupId}`);
-  redirect(`/groups/${groupId}/settle`);
+  const redirectPath = buildCreateRedirectPath(actionKind, { groupId });
+
+  try {
+    await db.transaction(async (tx) => {
+      await tx.insert(settlements).values({
+        id: generateId(),
+        groupId,
+        paidById,
+        paidToId,
+        amount: Math.round(amount * 100) / 100,
+        note,
+        reversalOfSettlementId: null,
+        date,
+      });
+
+      if (submissionToken) {
+        await tx.insert(idempotentSubmissions).values({
+          id: generateId(),
+          userId: user.id,
+          actionKind,
+          submissionToken,
+          redirectPath,
+        });
+      }
+    });
+  } catch (error) {
+    if (
+      submissionToken &&
+      isUniqueConstraintError(error) &&
+      (await replayExistingCreateAction(user.id, actionKind, submissionToken))
+    ) {
+      return;
+    }
+
+    throw error;
+  }
+
+  finishCreateAction(actionKind, redirectPath);
 }
 
 export async function reverseSettlement(groupId: string, settlementId: string) {

--- a/src/app/groups/[id]/confirm-delete-button.tsx
+++ b/src/app/groups/[id]/confirm-delete-button.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { ReactNode } from "react";
+import { PendingSubmitButton } from "@/components/pending-submit-button";
 
 interface ConfirmDeleteButtonProps {
   action: () => Promise<void>;
   message: string;
+  pendingLabel: ReactNode;
   className?: string;
   title?: string;
   children: ReactNode;
@@ -13,14 +15,15 @@ interface ConfirmDeleteButtonProps {
 export function ConfirmDeleteButton({
   action,
   message,
+  pendingLabel,
   className,
   title,
   children,
 }: ConfirmDeleteButtonProps) {
   return (
     <form action={action}>
-      <button
-        type="submit"
+      <PendingSubmitButton
+        pendingLabel={pendingLabel}
         className={className}
         title={title}
         onClick={(e) => {
@@ -30,7 +33,7 @@ export function ConfirmDeleteButton({
         }}
       >
         {children}
-      </button>
+      </PendingSubmitButton>
     </form>
   );
 }

--- a/src/app/groups/[id]/delete-group-button.tsx
+++ b/src/app/groups/[id]/delete-group-button.tsx
@@ -1,22 +1,19 @@
 "use client";
 
 import { deleteGroup } from "@/app/actions";
+import { ConfirmDeleteButton } from "./confirm-delete-button";
 
 export function DeleteGroupButton({ groupId }: { groupId: string }) {
   const action = deleteGroup.bind(null, groupId);
+
   return (
-    <form action={action}>
-      <button
-        type="submit"
-        className="text-xs text-slate-400 hover:text-red-500 transition-colors"
-        onClick={(e) => {
-          if (!confirm("Delete this group and all its expenses? This cannot be undone.")) {
-            e.preventDefault();
-          }
-        }}
-      >
-        Delete group
-      </button>
-    </form>
+    <ConfirmDeleteButton
+      action={action}
+      message="Delete this group and all its expenses? This cannot be undone."
+      pendingLabel="Deleting..."
+      className="text-xs text-slate-400 hover:text-red-500 transition-colors disabled:opacity-70 disabled:cursor-not-allowed"
+    >
+      Delete group
+    </ConfirmDeleteButton>
   );
 }

--- a/src/app/groups/[id]/expenses/new/expense-form.tsx
+++ b/src/app/groups/[id]/expenses/new/expense-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useId, useMemo, useState } from "react";
 import { createExpense, updateExpense } from "@/app/actions";
 import { computeSplits } from "@/lib/splits";
 import { formatCurrency, today } from "@/lib/format";
@@ -30,6 +30,7 @@ export function ExpenseForm({
   const editing = !!expense;
   const total = expense?.amount ?? 0;
   const paidByFieldId = "paid-by";
+  const submissionToken = useId();
 
   const [amount, setAmount] = useState(editing ? String(expense.amount) : "");
   const [paidById, setPaidById] = useState(editing ? expense.paidById : (members[0]?.id ?? ""));
@@ -113,6 +114,7 @@ export function ExpenseForm({
 
   return (
     <form action={action} className="space-y-5">
+      {!editing && <input type="hidden" name="_submissionToken" value={submissionToken} />}
       {/* Description */}
       <div>
         <label className="block text-sm font-medium text-slate-700 mb-1.5">Description</label>

--- a/src/app/groups/[id]/expenses/new/expense-form.tsx
+++ b/src/app/groups/[id]/expenses/new/expense-form.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { createExpense, updateExpense } from "@/app/actions";
+import { PendingSubmitButton } from "@/components/pending-submit-button";
 import { computeSplits } from "@/lib/splits";
 import { formatCurrency, today } from "@/lib/format";
 
@@ -358,13 +359,13 @@ export function ExpenseForm({
         </div>
       )}
 
-      <button
-        type="submit"
+      <PendingSubmitButton
         disabled={!isValid}
+        pendingLabel={editing ? "Saving..." : "Adding..."}
         className="w-full bg-green-600 text-white py-3 rounded-xl font-semibold hover:bg-green-700 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
       >
         {editing ? "Save Changes" : "Add Expense"}
-      </button>
+      </PendingSubmitButton>
     </form>
   );
 }

--- a/src/app/groups/[id]/expenses/new/expense-form.tsx
+++ b/src/app/groups/[id]/expenses/new/expense-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useId, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { createExpense, updateExpense } from "@/app/actions";
 import { computeSplits } from "@/lib/splits";
 import { formatCurrency, today } from "@/lib/format";
@@ -30,7 +30,7 @@ export function ExpenseForm({
   const editing = !!expense;
   const total = expense?.amount ?? 0;
   const paidByFieldId = "paid-by";
-  const submissionToken = useId();
+  const [submissionToken] = useState(() => crypto.randomUUID());
 
   const [amount, setAmount] = useState(editing ? String(expense.amount) : "");
   const [paidById, setPaidById] = useState(editing ? expense.paidById : (members[0]?.id ?? ""));

--- a/src/app/groups/[id]/expenses/new/expense-form.tsx
+++ b/src/app/groups/[id]/expenses/new/expense-form.tsx
@@ -22,15 +22,16 @@ export function ExpenseForm({
   groupId,
   members,
   expense,
+  submissionToken,
 }: {
   groupId: string;
   members: Member[];
   expense?: ExistingExpense;
+  submissionToken?: string;
 }) {
   const editing = !!expense;
   const total = expense?.amount ?? 0;
   const paidByFieldId = "paid-by";
-  const [submissionToken] = useState(() => crypto.randomUUID());
 
   const [amount, setAmount] = useState(editing ? String(expense.amount) : "");
   const [paidById, setPaidById] = useState(editing ? expense.paidById : (members[0]?.id ?? ""));
@@ -114,7 +115,9 @@ export function ExpenseForm({
 
   return (
     <form action={action} className="space-y-5">
-      {!editing && <input type="hidden" name="_submissionToken" value={submissionToken} />}
+      {!editing && submissionToken && (
+        <input type="hidden" name="_submissionToken" value={submissionToken} />
+      )}
       {/* Description */}
       <div>
         <label className="block text-sm font-medium text-slate-700 mb-1.5">Description</label>

--- a/src/app/groups/[id]/expenses/new/expense-form.tsx
+++ b/src/app/groups/[id]/expenses/new/expense-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { createExpense, updateExpense } from "@/app/actions";
 import { computeSplits } from "@/lib/splits";
 import { formatCurrency, today } from "@/lib/format";
@@ -18,20 +18,50 @@ type ExistingExpense = {
   splits: { memberId: string; amount: number }[];
 };
 
+type CreateExpenseFormProps = {
+  groupId: string;
+  members: Member[];
+  submissionToken: string;
+  expense?: undefined;
+};
+
+type EditExpenseFormProps = {
+  groupId: string;
+  members: Member[];
+  expense: ExistingExpense;
+  submissionToken?: never;
+};
+
 export function ExpenseForm({
   groupId,
   members,
   expense,
-  submissionToken,
-}: {
-  groupId: string;
-  members: Member[];
-  expense?: ExistingExpense;
-  submissionToken?: string;
-}) {
+  submissionToken: initialSubmissionToken,
+}: CreateExpenseFormProps | EditExpenseFormProps) {
   const editing = !!expense;
   const total = expense?.amount ?? 0;
   const paidByFieldId = "paid-by";
+  const [submissionToken, setSubmissionToken] = useState(initialSubmissionToken);
+
+  useEffect(() => {
+    if (editing) {
+      return;
+    }
+
+    const rotateToken = () => setSubmissionToken(crypto.randomUUID());
+
+    const refreshToken = (event: PageTransitionEvent) => {
+      if (event.persisted) {
+        rotateToken();
+      }
+    };
+
+    window.addEventListener("pageshow", refreshToken);
+
+    return () => {
+      window.removeEventListener("pageshow", refreshToken);
+    };
+  }, [editing]);
 
   const [amount, setAmount] = useState(editing ? String(expense.amount) : "");
   const [paidById, setPaidById] = useState(editing ? expense.paidById : (members[0]?.id ?? ""));

--- a/src/app/groups/[id]/expenses/new/page.tsx
+++ b/src/app/groups/[id]/expenses/new/page.tsx
@@ -6,6 +6,7 @@ export const dynamic = "force-dynamic";
 import { db } from "@/db";
 import { groups, members } from "@/db/schema";
 import { requireGroupAccess } from "@/lib/server/session";
+import { generateId } from "@/lib/utils";
 import { ExpenseForm } from "./expense-form";
 
 export default async function NewExpensePage({
@@ -21,6 +22,7 @@ export default async function NewExpensePage({
 
   const groupMembers = await db.select().from(members).where(eq(members.groupId, id));
   if (groupMembers.length === 0) notFound();
+  const submissionToken = generateId();
 
   return (
     <div className="space-y-6">
@@ -30,7 +32,11 @@ export default async function NewExpensePage({
         </a>
         <h1 className="text-2xl font-bold text-slate-900 mt-1">Add Expense</h1>
       </div>
-      <ExpenseForm groupId={id} members={groupMembers} />
+      <ExpenseForm
+        groupId={id}
+        members={groupMembers}
+        submissionToken={submissionToken}
+      />
     </div>
   );
 }

--- a/src/app/groups/[id]/page.tsx
+++ b/src/app/groups/[id]/page.tsx
@@ -13,6 +13,7 @@ import { requireGroupAccess } from "@/lib/server/session";
 import { buildActivityEvents, getPostSettlementEditedExpenseIds } from "@/lib/history";
 import { addMember, deleteExpense } from "@/app/actions";
 import { generateId } from "@/lib/utils";
+import { PendingSubmitButton } from "@/components/pending-submit-button";
 import { DeleteGroupButton } from "./delete-group-button";
 import { ConfirmDeleteButton } from "./confirm-delete-button";
 import { InviteUserForm } from "./invite-user-form";
@@ -245,7 +246,8 @@ export default async function GroupPage({
                     <ConfirmDeleteButton
                       action={deleteExpense.bind(null, id, expense.id)}
                       message="Delete this expense? This cannot be undone."
-                      className="text-slate-300 hover:text-red-400 transition-colors text-lg leading-none"
+                      pendingLabel="Deleting..."
+                      className="text-slate-300 hover:text-red-400 transition-colors text-lg leading-none disabled:opacity-70 disabled:cursor-not-allowed"
                       title="Delete expense"
                     >
                       ×
@@ -361,12 +363,12 @@ export default async function GroupPage({
               placeholder="Add a member…"
               className="flex-1 border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-transparent"
             />
-            <button
-              type="submit"
+            <PendingSubmitButton
+              pendingLabel="Adding..."
               className="bg-slate-100 hover:bg-slate-200 text-slate-700 px-3 py-2 rounded-lg text-sm font-medium transition-colors"
             >
               Add
-            </button>
+            </PendingSubmitButton>
           </form>
         </div>
       </section>

--- a/src/app/groups/[id]/page.tsx
+++ b/src/app/groups/[id]/page.tsx
@@ -12,6 +12,7 @@ import { formatCurrency, formatDate } from "@/lib/format";
 import { requireGroupAccess } from "@/lib/server/session";
 import { buildActivityEvents, getPostSettlementEditedExpenseIds } from "@/lib/history";
 import { addMember, deleteExpense } from "@/app/actions";
+import { generateId } from "@/lib/utils";
 import { DeleteGroupButton } from "./delete-group-button";
 import { ConfirmDeleteButton } from "./confirm-delete-button";
 import { InviteUserForm } from "./invite-user-form";
@@ -99,6 +100,7 @@ export default async function GroupPage({
   });
 
   const addMemberAction = addMember.bind(null, id);
+  const addMemberSubmissionToken = generateId();
 
   return (
     <div className="space-y-6">
@@ -353,6 +355,7 @@ export default async function GroupPage({
             </div>
           ))}
           <form action={addMemberAction} className="flex gap-2 p-3">
+            <input type="hidden" name="_submissionToken" value={addMemberSubmissionToken} />
             <input
               name="name"
               placeholder="Add a member…"

--- a/src/app/groups/[id]/settle/page.tsx
+++ b/src/app/groups/[id]/settle/page.tsx
@@ -12,6 +12,7 @@ import { requireGroupAccess } from "@/lib/server/session";
 import { hasExpenseEditsAfterSettlementStarted } from "@/lib/history";
 import { generateId } from "@/lib/utils";
 import { createSettlement, reverseSettlement } from "@/app/actions";
+import { PendingSubmitButton } from "@/components/pending-submit-button";
 import { ConfirmDeleteButton } from "../confirm-delete-button";
 
 type MemberRow = typeof members.$inferSelect;
@@ -136,12 +137,12 @@ export default async function SettlePage({
                   <input type="hidden" name="paidToId" value={debt.toId} />
                   <input type="hidden" name="amount" value={debt.amount} />
                   <input type="hidden" name="date" value={today()} />
-                  <button
-                    type="submit"
+                  <PendingSubmitButton
+                    pendingLabel="Recording..."
                     className="w-full py-2 bg-green-600 text-white text-sm font-semibold rounded-lg hover:bg-green-700 transition-colors"
                   >
                     Mark as Settled
-                  </button>
+                  </PendingSubmitButton>
                 </form>
               </div>
             ))}
@@ -223,12 +224,12 @@ export default async function SettlePage({
               className="w-full border border-slate-300 rounded-lg px-2.5 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-500"
             />
           </div>
-          <button
-            type="submit"
+          <PendingSubmitButton
+            pendingLabel="Recording..."
             className="w-full py-2.5 bg-green-600 text-white text-sm font-semibold rounded-lg hover:bg-green-700 transition-colors"
           >
             Record Payment
-          </button>
+          </PendingSubmitButton>
         </form>
       </section>
 
@@ -272,7 +273,8 @@ export default async function SettlePage({
                   <ConfirmDeleteButton
                     action={reverseSettlement.bind(null, id, s.id)}
                     message="Record a reversing payment for this entry?"
-                    className="text-sm text-amber-700 hover:text-amber-800 font-medium transition-colors"
+                    pendingLabel="Reversing..."
+                    className="text-sm text-amber-700 hover:text-amber-800 font-medium transition-colors disabled:opacity-70 disabled:cursor-not-allowed"
                     title="Reverse payment"
                   >
                     Reverse payment

--- a/src/app/groups/[id]/settle/page.tsx
+++ b/src/app/groups/[id]/settle/page.tsx
@@ -10,6 +10,7 @@ import { calculateBalances, simplifyDebts } from "@/lib/balances";
 import { formatCurrency, formatDate, today } from "@/lib/format";
 import { requireGroupAccess } from "@/lib/server/session";
 import { hasExpenseEditsAfterSettlementStarted } from "@/lib/history";
+import { generateId } from "@/lib/utils";
 import { createSettlement, reverseSettlement } from "@/app/actions";
 import { ConfirmDeleteButton } from "../confirm-delete-button";
 
@@ -86,6 +87,7 @@ export default async function SettlePage({
   );
 
   const settleAction = createSettlement.bind(null, id);
+  const manualSettlementSubmissionToken = generateId();
 
   return (
     <div className="space-y-6">
@@ -129,6 +131,7 @@ export default async function SettlePage({
                   <span className="text-green-600 font-bold"> {formatCurrency(debt.amount)}</span>
                 </p>
                 <form action={settleAction}>
+                  <input type="hidden" name="_submissionToken" value={generateId()} />
                   <input type="hidden" name="paidById" value={debt.fromId} />
                   <input type="hidden" name="paidToId" value={debt.toId} />
                   <input type="hidden" name="amount" value={debt.amount} />
@@ -153,6 +156,11 @@ export default async function SettlePage({
           action={settleAction}
           className="bg-white border border-slate-200 rounded-xl p-4 space-y-3"
         >
+          <input
+            type="hidden"
+            name="_submissionToken"
+            value={manualSettlementSubmissionToken}
+          />
           <div className="grid grid-cols-2 gap-3">
             <div>
               <label className="block text-xs font-medium text-slate-500 mb-1">From</label>

--- a/src/app/groups/new/new-group-form.tsx
+++ b/src/app/groups/new/new-group-form.tsx
@@ -1,12 +1,29 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Plus, X } from "lucide-react";
 
 import { createGroup } from "@/app/actions";
 
-export function NewGroupForm({ submissionToken }: { submissionToken: string }) {
+export function NewGroupForm({ submissionToken: initialSubmissionToken }: { submissionToken: string }) {
   const [memberInputs, setMemberInputs] = useState(["", ""]);
+  const [submissionToken, setSubmissionToken] = useState(initialSubmissionToken);
+
+  useEffect(() => {
+    const rotateToken = () => setSubmissionToken(crypto.randomUUID());
+
+    const refreshToken = (event: PageTransitionEvent) => {
+      if (event.persisted) {
+        rotateToken();
+      }
+    };
+
+    window.addEventListener("pageshow", refreshToken);
+
+    return () => {
+      window.removeEventListener("pageshow", refreshToken);
+    };
+  }, []);
 
   const addMember = () => setMemberInputs((p) => [...p, ""]);
   const removeMember = (i: number) =>

--- a/src/app/groups/new/new-group-form.tsx
+++ b/src/app/groups/new/new-group-form.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { Plus, X } from "lucide-react";
 
 import { createGroup } from "@/app/actions";
+import { PendingSubmitButton } from "@/components/pending-submit-button";
 
 export function NewGroupForm({ submissionToken: initialSubmissionToken }: { submissionToken: string }) {
   const [memberInputs, setMemberInputs] = useState(["", ""]);
@@ -80,12 +81,12 @@ export function NewGroupForm({ submissionToken: initialSubmissionToken }: { subm
         </button>
       </div>
 
-      <button
-        type="submit"
+      <PendingSubmitButton
+        pendingLabel="Creating..."
         className="w-full bg-green-600 text-white py-3 rounded-xl font-semibold hover:bg-green-700 transition-colors"
       >
         Create Group
-      </button>
+      </PendingSubmitButton>
     </form>
   );
 }

--- a/src/app/groups/new/new-group-form.tsx
+++ b/src/app/groups/new/new-group-form.tsx
@@ -5,9 +5,8 @@ import { Plus, X } from "lucide-react";
 
 import { createGroup } from "@/app/actions";
 
-export function NewGroupForm() {
+export function NewGroupForm({ submissionToken }: { submissionToken: string }) {
   const [memberInputs, setMemberInputs] = useState(["", ""]);
-  const [submissionToken] = useState(() => crypto.randomUUID());
 
   const addMember = () => setMemberInputs((p) => [...p, ""]);
   const removeMember = (i: number) =>

--- a/src/app/groups/new/new-group-form.tsx
+++ b/src/app/groups/new/new-group-form.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useState } from "react";
+import { useId, useState } from "react";
 import { Plus, X } from "lucide-react";
 
 import { createGroup } from "@/app/actions";
 
 export function NewGroupForm() {
   const [memberInputs, setMemberInputs] = useState(["", ""]);
+  const submissionToken = useId();
 
   const addMember = () => setMemberInputs((p) => [...p, ""]);
   const removeMember = (i: number) =>
@@ -16,6 +17,7 @@ export function NewGroupForm() {
 
   return (
     <form action={createGroup} className="space-y-5">
+      <input type="hidden" name="_submissionToken" value={submissionToken} />
       <div>
         <label className="block text-sm font-medium text-slate-700 mb-1.5">
           Group Name

--- a/src/app/groups/new/new-group-form.tsx
+++ b/src/app/groups/new/new-group-form.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { useId, useState } from "react";
+import { useState } from "react";
 import { Plus, X } from "lucide-react";
 
 import { createGroup } from "@/app/actions";
 
 export function NewGroupForm() {
   const [memberInputs, setMemberInputs] = useState(["", ""]);
-  const submissionToken = useId();
+  const [submissionToken] = useState(() => crypto.randomUUID());
 
   const addMember = () => setMemberInputs((p) => [...p, ""]);
   const removeMember = (i: number) =>

--- a/src/app/groups/new/page.tsx
+++ b/src/app/groups/new/page.tsx
@@ -1,11 +1,13 @@
 import Link from "next/link";
 import { requireUser } from "@/lib/server/session";
+import { generateId } from "@/lib/utils";
 import { NewGroupForm } from "./new-group-form";
 
 export const dynamic = "force-dynamic";
 
 export default async function NewGroupPage() {
   await requireUser();
+  const submissionToken = generateId();
 
   return (
     <div className="space-y-6">
@@ -18,7 +20,7 @@ export default async function NewGroupPage() {
           Add at least 2 members to get started
         </p>
       </div>
-      <NewGroupForm />
+      <NewGroupForm submissionToken={submissionToken} />
     </div>
   );
 }

--- a/src/components/pending-submit-button.tsx
+++ b/src/components/pending-submit-button.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+import { useFormStatus } from "react-dom";
+
+import { cn } from "@/lib/utils";
+
+type PendingSubmitButtonProps = Omit<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  "children"
+> & {
+  children: ReactNode;
+  pendingLabel: ReactNode;
+};
+
+export function PendingSubmitButton({
+  children,
+  pendingLabel,
+  className,
+  disabled,
+  type = "submit",
+  ...props
+}: PendingSubmitButtonProps) {
+  const { pending } = useFormStatus();
+  const isDisabled = disabled || pending;
+
+  return (
+    <button
+      {...props}
+      type={type}
+      disabled={isDisabled}
+      className={cn("disabled:cursor-not-allowed disabled:opacity-70", className)}
+    >
+      {pending ? pendingLabel : children}
+    </button>
+  );
+}

--- a/src/db/__tests__/idempotent-submissions.test.ts
+++ b/src/db/__tests__/idempotent-submissions.test.ts
@@ -1,0 +1,101 @@
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { createClient } from "@libsql/client";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/libsql";
+import { migrate } from "drizzle-orm/libsql/migrator";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { idempotentSubmissions, users } from "../schema";
+
+type TestDatabase = {
+  cleanup: () => void;
+  db: ReturnType<typeof drizzle<typeof import("../schema")>>;
+};
+
+function createTestDatabase(): TestDatabase {
+  const tempDir = mkdtempSync(path.join(tmpdir(), "tab-track-idempotency-"));
+  const dbPath = path.join(tempDir, "test.db");
+  const client = createClient({ url: `file:${dbPath}` });
+  const db = drizzle(client, {
+    schema: { idempotentSubmissions, users },
+  });
+
+  const cleanup = () => {
+    client.close();
+    rmSync(tempDir, { force: true, recursive: true });
+  };
+
+  return { cleanup, db };
+}
+
+const cleanups: Array<() => void> = [];
+
+afterEach(() => {
+  while (cleanups.length > 0) {
+    cleanups.pop()?.();
+  }
+});
+
+describe("idempotentSubmissions", () => {
+  it("rejects duplicate submission tokens for the same user and action kind", async () => {
+    const { cleanup, db } = createTestDatabase();
+    cleanups.push(cleanup);
+    await migrate(db, {
+      migrationsFolder: path.resolve(process.cwd(), "drizzle"),
+    });
+
+    await db.insert(users).values({
+      id: "user-1",
+      email: "user@example.com",
+      displayName: "User One",
+      passwordHash: "hash",
+    });
+
+    await db.insert(idempotentSubmissions).values({
+      id: "submission-1",
+      userId: "user-1",
+      actionKind: "createExpense",
+      submissionToken: "token-123",
+      redirectPath: "/groups/group-1",
+    });
+
+    await expect(
+      db.insert(idempotentSubmissions).values({
+        id: "submission-2",
+        userId: "user-1",
+        actionKind: "createExpense",
+        submissionToken: "token-123",
+        redirectPath: "/groups/group-1",
+      })
+    ).rejects.toThrow(/unique/i);
+  });
+
+  it("deletes a user's idempotent submissions when the user is removed", async () => {
+    const { cleanup, db } = createTestDatabase();
+    cleanups.push(cleanup);
+    await migrate(db, {
+      migrationsFolder: path.resolve(process.cwd(), "drizzle"),
+    });
+
+    await db.insert(users).values({
+      id: "user-1",
+      email: "user@example.com",
+      displayName: "User One",
+      passwordHash: "hash",
+    });
+
+    await db.insert(idempotentSubmissions).values({
+      id: "submission-1",
+      userId: "user-1",
+      actionKind: "createGroup",
+      submissionToken: "token-123",
+      redirectPath: "/groups/group-1",
+    });
+
+    await db.delete(users).where(eq(users.id, "user-1"));
+
+    await expect(db.select().from(idempotentSubmissions)).resolves.toEqual([]);
+  });
+});

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -132,3 +132,26 @@ export const settlements = sqliteTable(
     }),
   ]
 );
+
+export const idempotentSubmissions = sqliteTable(
+  "idempotent_submissions",
+  {
+    id: text("id").primaryKey(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    actionKind: text("action_kind", {
+      enum: ["createGroup", "createExpense", "createSettlement", "addMember"],
+    }).notNull(),
+    submissionToken: text("submission_token").notNull(),
+    redirectPath: text("redirect_path").notNull(),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+  },
+  (table) => ({
+    userActionTokenUniqueIndex: uniqueIndex(
+      "idempotent_submissions_user_action_token_unique"
+    ).on(table.userId, table.actionKind, table.submissionToken),
+  })
+);

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,5 +1,6 @@
 import { sql } from "drizzle-orm";
 import { foreignKey, real, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
+import { CREATE_ACTION_KINDS } from "@/lib/idempotency";
 
 export const users = sqliteTable(
   "users",
@@ -141,7 +142,7 @@ export const idempotentSubmissions = sqliteTable(
       .notNull()
       .references(() => users.id, { onDelete: "cascade" }),
     actionKind: text("action_kind", {
-      enum: ["createGroup", "createExpense", "createSettlement", "addMember"],
+      enum: CREATE_ACTION_KINDS,
     }).notNull(),
     submissionToken: text("submission_token").notNull(),
     redirectPath: text("redirect_path").notNull(),

--- a/src/lib/__tests__/idempotency.test.ts
+++ b/src/lib/__tests__/idempotency.test.ts
@@ -17,6 +17,13 @@ describe("readSubmissionToken", () => {
   it("returns null when the hidden field is missing", () => {
     expect(readSubmissionToken(new FormData())).toBeNull();
   });
+
+  it("returns null for blank submission tokens", () => {
+    const formData = new FormData();
+    formData.set("_submissionToken", "   ");
+
+    expect(readSubmissionToken(formData)).toBeNull();
+  });
 });
 
 describe("buildCreateRedirectPath", () => {

--- a/src/lib/__tests__/idempotency.test.ts
+++ b/src/lib/__tests__/idempotency.test.ts
@@ -31,6 +31,18 @@ describe("buildCreateRedirectPath", () => {
       "/groups/group-1"
     );
   });
+
+  it("builds the redirect path for a created settlement", () => {
+    expect(buildCreateRedirectPath("createSettlement", { groupId: "group-1" })).toBe(
+      "/groups/group-1/settle"
+    );
+  });
+
+  it("keeps add-member redirects on the group page", () => {
+    expect(buildCreateRedirectPath("addMember", { groupId: "group-1" })).toBe(
+      "/groups/group-1"
+    );
+  });
 });
 
 describe("CREATE_ACTION_KINDS", () => {

--- a/src/lib/__tests__/idempotency.test.ts
+++ b/src/lib/__tests__/idempotency.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CREATE_ACTION_KINDS,
+  buildCreateRedirectPath,
+  readSubmissionToken,
+} from "../idempotency";
+
+describe("readSubmissionToken", () => {
+  it("returns a trimmed token when the hidden field is present", () => {
+    const formData = new FormData();
+    formData.set("_submissionToken", "  token-123  ");
+
+    expect(readSubmissionToken(formData)).toBe("token-123");
+  });
+
+  it("returns null when the hidden field is missing", () => {
+    expect(readSubmissionToken(new FormData())).toBeNull();
+  });
+});
+
+describe("buildCreateRedirectPath", () => {
+  it("builds the redirect path for a created group", () => {
+    expect(buildCreateRedirectPath("createGroup", { groupId: "group-1" })).toBe(
+      "/groups/group-1"
+    );
+  });
+
+  it("builds the redirect path for a created expense", () => {
+    expect(buildCreateRedirectPath("createExpense", { groupId: "group-1" })).toBe(
+      "/groups/group-1"
+    );
+  });
+});
+
+describe("CREATE_ACTION_KINDS", () => {
+  it("includes every idempotent create action", () => {
+    expect(CREATE_ACTION_KINDS).toEqual([
+      "createGroup",
+      "createExpense",
+      "createSettlement",
+      "addMember",
+    ]);
+  });
+});

--- a/src/lib/idempotency.ts
+++ b/src/lib/idempotency.ts
@@ -1,0 +1,27 @@
+export const CREATE_ACTION_KINDS = [
+  "createGroup",
+  "createExpense",
+  "createSettlement",
+  "addMember",
+] as const;
+
+export type CreateActionKind = (typeof CREATE_ACTION_KINDS)[number];
+
+export function readSubmissionToken(formData: FormData): string | null {
+  const value = formData.get("_submissionToken");
+
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+export function buildCreateRedirectPath(
+  actionKind: CreateActionKind,
+  ids: { groupId: string }
+): string {
+  switch (actionKind) {
+    case "createGroup":
+    case "createExpense":
+    case "createSettlement":
+    case "addMember":
+      return `/groups/${ids.groupId}`;
+  }
+}

--- a/src/lib/idempotency.ts
+++ b/src/lib/idempotency.ts
@@ -20,8 +20,9 @@ export function buildCreateRedirectPath(
   switch (actionKind) {
     case "createGroup":
     case "createExpense":
-    case "createSettlement":
     case "addMember":
       return `/groups/${ids.groupId}`;
+    case "createSettlement":
+      return `/groups/${ids.groupId}/settle`;
   }
 }


### PR DESCRIPTION
## Summary
- add idempotent create submission storage and server-side replay protection for create group, add expense, add member, and record payment flows
- add shared pending submit button UX so write actions immediately disable and show in-flight labels
- extend Playwright and test coverage for double-submit regressions, pending states, and restored-form token refresh behavior

## Why
Users were seeing lag after submitting write forms, which made a second click likely and created duplicate groups, expenses, members, or settlement records. This change improves perceived responsiveness and adds a server-side safety net when duplicate submissions race.

## Validation
- `npm run lint`
- `npm test`
- `npm run build`
- `npm run test:e2e -- --project="Desktop Chrome"`
- `npm run test:e2e -- --project="iPhone 14"`

Closes #10
