### PR TITLE
[codex] list shared group access emails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ e2e-test.db-wal
 .DS_Store
 *.pem
 *.tsbuildinfo
+
+# local planning/spec artifacts
+docs/superpowers/

--- a/e2e/groups.spec.ts
+++ b/e2e/groups.spec.ts
@@ -68,4 +68,31 @@ test.describe("Group management", () => {
     await expect(page).toHaveURL(/\/groups\/[^/]+$/);
     await expect(page.getByText("4 members")).toBeVisible();
   });
+
+  test("shows owner and shared account emails in app access", async ({ page, browser }) => {
+    const owner = await signUpAndLogin(page);
+    await page.goto("/groups/new");
+    await page.getByPlaceholder("e.g. Tokyo Trip, Apartment").fill("Shared Cabin");
+    await page.getByPlaceholder("Member 1").fill("Alice");
+    await page.getByPlaceholder("Member 2").fill("Bob");
+    await page.getByRole("button", { name: "Create Group" }).click();
+
+    await expect(page).toHaveURL(/\/groups\/[^/]+$/);
+    await expect(page.getByText(owner.email)).toBeVisible();
+
+    const invitedContext = await browser.newContext();
+    const invitedPage = await invitedContext.newPage();
+    const invited = await signUpAndLogin(invitedPage);
+    await invitedContext.close();
+
+    await page.getByPlaceholder("friend@example.com").fill(invited.email);
+    await page.getByRole("button", { name: "Share Group" }).click();
+
+    const appAccessSection = page
+      .locator("section")
+      .filter({ has: page.getByRole("heading", { name: "App Access" }) });
+
+    await expect(page.getByText(`Shared with ${invited.email}.`)).toBeVisible();
+    await expect(appAccessSection.getByText(invited.email, { exact: true })).toBeVisible();
+  });
 });

--- a/src/app/groups/[id]/page.tsx
+++ b/src/app/groups/[id]/page.tsx
@@ -6,9 +6,19 @@ import { Plus, ArrowRight, Pencil } from "lucide-react";
 import { eq, inArray } from "drizzle-orm";
 
 import { db } from "@/db";
-import { expenseRevisions, expenseSplits, expenses, groups, members, settlements } from "@/db/schema";
+import {
+  expenseRevisions,
+  expenseSplits,
+  expenses,
+  groupAccess,
+  groups,
+  members,
+  settlements,
+  users,
+} from "@/db/schema";
 import { calculateBalances, simplifyDebts } from "@/lib/balances";
 import { formatCurrency, formatDate } from "@/lib/format";
+import { buildGroupShareList } from "@/lib/group-shares";
 import { requireGroupAccess } from "@/lib/server/session";
 import { buildActivityEvents, getPostSettlementEditedExpenseIds } from "@/lib/history";
 import { addMember, deleteExpense } from "@/app/actions";
@@ -46,6 +56,21 @@ export default async function GroupPage({
       .orderBy(expenses.date),
     db.select().from(settlements).where(eq(settlements.groupId, id)),
   ]);
+  const sharedUsers = buildGroupShareList(
+    (
+      await db
+        .select({
+          email: users.email,
+          role: groupAccess.role,
+        })
+        .from(groupAccess)
+        .innerJoin(users, eq(groupAccess.userId, users.id))
+        .where(eq(groupAccess.groupId, id))
+    ).map((share) => ({
+      email: share.email,
+      role: share.role,
+    }))
+  );
 
   const expenseIds = groupExpenses.map((expense) => expense.id);
   const [groupExpenseSplits, groupExpenseRevisions]: [ExpenseSplitRow[], ExpenseRevisionRow[]] =
@@ -375,6 +400,16 @@ export default async function GroupPage({
             Share this group with friends who already created an account.
           </p>
           <InviteUserForm groupId={id} />
+          <div className="mt-4 border-t border-slate-100 pt-4">
+            <h3 className="text-sm font-medium text-slate-900">Shared with</h3>
+            <div className="mt-2 space-y-2">
+              {sharedUsers.map((sharedUser) => (
+                <p key={sharedUser.email} className="text-sm text-slate-600">
+                  {sharedUser.email}
+                </p>
+              ))}
+            </div>
+          </div>
         </div>
       </section>
 

--- a/src/lib/__tests__/group-shares.test.ts
+++ b/src/lib/__tests__/group-shares.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "vitest";
+
+import { buildGroupShareList } from "@/lib/group-shares";
+
+describe("buildGroupShareList", () => {
+  test("sorts the owner first and member emails alphabetically", () => {
+    expect(
+      buildGroupShareList([
+        { email: "zoe@example.com", role: "member" },
+        { email: "owner@example.com", role: "owner" },
+        { email: "amy@example.com", role: "member" },
+      ])
+    ).toEqual([
+      { email: "owner@example.com", role: "owner" },
+      { email: "amy@example.com", role: "member" },
+      { email: "zoe@example.com", role: "member" },
+    ]);
+  });
+});

--- a/src/lib/group-shares.ts
+++ b/src/lib/group-shares.ts
@@ -1,0 +1,14 @@
+export type GroupShare = {
+  email: string;
+  role: "owner" | "member";
+};
+
+export function buildGroupShareList(shares: GroupShare[]): GroupShare[] {
+  return [...shares].sort((left, right) => {
+    if (left.role !== right.role) {
+      return left.role === "owner" ? -1 : 1;
+    }
+
+    return left.email.localeCompare(right.email);
+  });
+}


### PR DESCRIPTION
## Summary
- list every authorized app account email in the group page `App Access` section, including the owner
- sort the owner first and remaining shared emails alphabetically with focused unit coverage for the ordering helper
- add end-to-end coverage that signs up a second user, shares the group, and verifies both emails appear on the group page

## Validation
- `npm run lint`
- `npm test`
- `npm run build`
- `npm run test:e2e -- --project="Desktop Chrome"`
- `npm run test:e2e -- --project="iPhone 14"`

Closes #13
